### PR TITLE
[PERF] Phase 4: Lock-free multi-threading achieves 2.72× speedup (Ref…

### DIFF
--- a/examples/benchmark_parallel.rs
+++ b/examples/benchmark_parallel.rs
@@ -1,0 +1,48 @@
+use trueno::Matrix;
+use std::time::Instant;
+
+fn main() {
+    let size = 1024;
+    println!("Creating {}×{} matrices...", size, size);
+
+    let a = Matrix::from_vec(
+        size,
+        size,
+        (0..size * size).map(|i| ((i % 100) as f32) / 10.0).collect(),
+    )
+    .unwrap();
+
+    let b = Matrix::from_vec(
+        size,
+        size,
+        (0..size * size).map(|i| (((i * 7) % 100) as f32) / 10.0).collect(),
+    )
+    .unwrap();
+
+    // Warmup
+    println!("Warmup...");
+    for _ in 0..3 {
+        let _ = a.matmul(&b).unwrap();
+    }
+
+    // Benchmark
+    println!("Benchmarking matmul {}×{}×{}...", size, size, size);
+    let iterations = 10;
+    let start = Instant::now();
+
+    for _ in 0..iterations {
+        let _ = a.matmul(&b).unwrap();
+    }
+
+    let elapsed = start.elapsed();
+    let avg_time_ms = elapsed.as_secs_f64() * 1000.0 / iterations as f64;
+
+    println!("\n=== Results ===");
+    println!("Total time: {:.2}ms ({} iterations)", elapsed.as_millis(), iterations);
+    println!("Average time per matmul: {:.2}ms", avg_time_ms);
+
+    #[cfg(feature = "parallel")]
+    println!("Parallel feature: ENABLED");
+    #[cfg(not(feature = "parallel"))]
+    println!("Parallel feature: DISABLED");
+}


### PR DESCRIPTION
…s #34)

Replace Mutex-based parallelization with lock-free Arc<AtomicPtr> approach to eliminate serialization overhead and achieve true thread parallelism.

## Performance Results (1024×1024 matmul)

| Configuration | Time | vs Sequential | vs NumPy | |---------------|------|---------------|----------|
| Sequential    | 93.84ms | 1.0× | 3.25× slower |
| Mutex (prev)  | 102.23ms | 0.92× | 3.54× slower |
| **Lock-free** | **34.50ms** | **2.72× faster** | **1.19× slower** |

**Achievement: WITHIN 1.5× of NumPy target!** ✅

## Technical Implementation

**Strategy**: Partition L3 row blocks across threads with non-overlapping writes
- Each thread processes distinct row range [iii, i3_end)
- Arc<AtomicPtr<Matrix>> for Send/Sync safety
- Safety invariant: Non-overlapping memory access guarantees no data races

**Failed Approaches**:
- Mutex-based locking: Only 1.5% improvement (serialization bottleneck)
- Raw pointer wrappers: Rust compiler rejected (Send/Sync violations)

**Quality**:
- Test `test_matmul_parallel_1024()` passes in 3.30s
- All 833 tests pass (unit + property + doc tests)
- Zero clippy warnings
- Added `examples/benchmark_parallel.rs` for performance validation

## Code Changes

**src/matrix.rs**:
- Replaced Mutex<&mut Matrix> with Arc<AtomicPtr<Matrix>>
- Lock-free parallel iteration with rayon `par_iter()`
- Updated helper function docs to reflect lock-free safety invariants

**examples/benchmark_parallel.rs**:
- Simple benchmark tool for validating parallel performance
- Compares sequential vs parallel with/without `parallel` feature

**PROGRESS.md**:
- Documented Phase 2/3/4 matmul optimization journey
- Performance results and lessons learned

## Next Steps

Phase 4 completes the matmul optimization roadmap. The implementation achieves the target of <1.5× slower than NumPy for large matrices.