### PR TITLE
feat: Implement async GPU command batching API (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing ✅
 
-- All 928 tests passing with updated dependencies
-- 30/30 GPU tests pass with wgpu v27
+- All 937 tests passing with updated dependencies
+- 38/38 GPU tests pass with wgpu v27 (including 8 new batch tests)
 - Benchmark infrastructure verified with criterion 0.7
 - Zero clippy warnings maintained
+
+### Added ✨
+
+- **Async GPU Command Batching API** (v0.3.0 deliverable - Phase 1)
+  - **Goal**: Reduce GPU transfer overhead by 2x for chained operations
+  - **New types**:
+    - `GpuCommandBatch`: Command builder for batching GPU operations
+    - `BufferId`: Type-safe buffer identifier for intermediate results
+  - **Operations supported**: `relu`, `scale`, `add`, `mul`, `dot`
+  - **Architecture**: Command Builder pattern for explicit batching control
+    - `upload()`: Queue data for GPU upload
+    - `relu()`, `scale()`, `add()`, `mul()`, `dot()`: Queue operations (no GPU execution)
+    - `execute()`: Execute all queued operations in single batch
+    - `read()`: Download results from GPU
+  - **Transfer reduction**:
+    - Before: `relu + scale + add` = 6 transfers (3 up, 3 down)
+    - After: 2 transfers (1 up, 1 down) = **3x reduction**
+  - **New GPU shaders**:
+    - `SCALE_SHADER`: Element-wise scalar multiplication
+    - `VEC_MUL_SHADER`: Element-wise vector multiplication
+  - **Tests**:
+    - 8 comprehensive tests (buffer allocation, operation queuing, error handling, end-to-end execution)
+    - Integration test validates full workflow: upload → relu → scale → add → read
+  - **Dependencies**: Added `tokio` (dev-dependency) for async test support
 
 ## [0.7.0] - 2025-11-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,6 +1962,7 @@ dependencies = [
  "proptest",
  "rayon",
  "thiserror 2.0.17",
+ "tokio",
  "wgpu",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ futures-intrusive = { version = "0.5", optional = true }
 [dev-dependencies]
 proptest = "1.9"
 criterion = "0.7"
+tokio = { version = "1", features = ["macros", "rt"] }
 
 [features]
 default = []

--- a/src/backends/gpu/shaders.rs
+++ b/src/backends/gpu/shaders.rs
@@ -65,6 +65,49 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 }
 "#;
 
+/// Element-wise multiplication shader (WGSL)
+///
+/// Computes c = a * b element-wise
+pub const VEC_MUL_SHADER: &str = r#"
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let idx = global_id.x;
+    let len = arrayLength(&a);
+
+    if (idx < len) {
+        c[idx] = a[idx] * b[idx];
+    }
+}
+"#;
+
+/// Scalar multiplication shader (WGSL)
+///
+/// Computes output = input * scalar element-wise
+pub const SCALE_SHADER: &str = r#"
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+struct ScaleParams {
+    scalar: f32,
+}
+
+@group(0) @binding(2) var<uniform> params: ScaleParams;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let idx = global_id.x;
+    let len = arrayLength(&input);
+
+    if (idx < len) {
+        output[idx] = input[idx] * params.scalar;
+    }
+}
+"#;
+
 /// Dot product reduction shader (WGSL)
 ///
 /// Computes sum(a[i] * b[i]) using parallel reduction


### PR DESCRIPTION
Adds GpuCommandBatch for reducing GPU transfer overhead by batching multiple operations together. This is the Phase 1 implementation of the async GPU API (v0.3.0 deliverable).

Key Features:
- Command Builder pattern for explicit batching control
- BufferId system for type-safe buffer management
- 5 operations supported: relu, scale, add, mul, dot
- 3x reduction in GPU transfers (6→2 for 3 chained ops)

Implementation Details:
- execute(): Creates GPU buffers, uploads data, executes all operations
- read(): Downloads results from GPU via staging buffer
- Helper methods: execute_unary_op() and execute_binary_op()
- New shaders: SCALE_SHADER and VEC_MUL_SHADER

Testing:
- 8 comprehensive tests (buffer allocation, queuing, execution, errors)
- Integration test: upload → relu → scale → add → read
- All 937 tests passing

Technical Changes:
- Added tokio dev-dependency for async test support
- Updated CHANGELOG with detailed feature description
- Zero clippy warnings maintained

Success Criteria (v0.3.0):
✅ 2x fewer GPU transfers for chained operations
⏳ Performance improvement (benchmarking pending)
✅ Backward compatible (existing sync API unchanged)