### PR TITLE
fix: Replace .unwrap() with .expect() in examples and fix formatting

### DIFF
--- a/examples/benchmark_matrix_suite.rs
+++ b/examples/benchmark_matrix_suite.rs
@@ -22,7 +22,7 @@ fn main() {
                 .map(|i| ((i % 100) as f32) / 10.0)
                 .collect(),
         )
-        .unwrap();
+        .expect("Failed to create matrix A");
 
         let matrix_b = Matrix::from_vec(
             rows,
@@ -31,7 +31,7 @@ fn main() {
                 .map(|i| (((i * 7) % 100) as f32) / 10.0)
                 .collect(),
         )
-        .unwrap();
+        .expect("Failed to create matrix B");
 
         let vector_data: Vec<f32> = (0..cols).map(|i| ((i % 50) as f32) / 5.0).collect();
         let vector = Vector::from_slice(&vector_data);
@@ -43,13 +43,13 @@ fn main() {
 
             // Warmup
             for _ in 0..2 {
-                let _ = matrix_a.matmul(&matrix_b).unwrap();
+                let _ = matrix_a.matmul(&matrix_b).expect("Warmup matmul failed");
             }
 
             let iterations = if rows <= 512 { 10 } else { 5 };
             let start = Instant::now();
             for _ in 0..iterations {
-                let _ = matrix_a.matmul(&matrix_b).unwrap();
+                let _ = matrix_a.matmul(&matrix_b).expect("Benchmark matmul failed");
             }
             let elapsed = start.elapsed();
             let avg_ms = elapsed.as_secs_f64() * 1000.0 / iterations as f64;
@@ -63,13 +63,13 @@ fn main() {
 
         // Warmup
         for _ in 0..3 {
-            let _ = matrix_a.matvec(&vector).unwrap();
+            let _ = matrix_a.matvec(&vector).expect("Warmup matvec failed");
         }
 
         let iterations = if rows <= 512 { 100 } else { 20 };
         let start = Instant::now();
         for _ in 0..iterations {
-            let _ = matrix_a.matvec(&vector).unwrap();
+            let _ = matrix_a.matvec(&vector).expect("Benchmark matvec failed");
         }
         let elapsed = start.elapsed();
         let avg_us = elapsed.as_micros() as f64 / iterations as f64;
@@ -82,13 +82,13 @@ fn main() {
 
         // Warmup
         for _ in 0..3 {
-            let _ = Matrix::vecmat(&vector, &matrix_a).unwrap();
+            let _ = Matrix::vecmat(&vector, &matrix_a).expect("Warmup vecmat failed");
         }
 
         let iterations = if rows <= 512 { 100 } else { 20 };
         let start = Instant::now();
         for _ in 0..iterations {
-            let _ = Matrix::vecmat(&vector, &matrix_a).unwrap();
+            let _ = Matrix::vecmat(&vector, &matrix_a).expect("Benchmark vecmat failed");
         }
         let elapsed = start.elapsed();
         let avg_us = elapsed.as_micros() as f64 / iterations as f64;

--- a/examples/benchmark_matvec.rs
+++ b/examples/benchmark_matvec.rs
@@ -18,14 +18,14 @@ fn main() {
                 .map(|i| ((i % 100) as f32) / 10.0)
                 .collect(),
         )
-        .unwrap();
+        .expect("Failed to create matrix");
 
         let vector_data: Vec<f32> = (0..cols).map(|i| ((i % 50) as f32) / 5.0).collect();
         let vector = trueno::Vector::from_slice(&vector_data);
 
         // Warmup
         for _ in 0..3 {
-            let _ = matrix.matvec(&vector).unwrap();
+            let _ = matrix.matvec(&vector).expect("Warmup matvec failed");
         }
 
         // Benchmark
@@ -33,7 +33,7 @@ fn main() {
         let start = Instant::now();
 
         for _ in 0..iterations {
-            let _ = matrix.matvec(&vector).unwrap();
+            let _ = matrix.matvec(&vector).expect("Benchmark matvec failed");
         }
 
         let elapsed = start.elapsed();

--- a/examples/benchmark_matvec_parallel.rs
+++ b/examples/benchmark_matvec_parallel.rs
@@ -25,7 +25,7 @@ fn main() {
                 .map(|i| ((i % 100) as f32) / 10.0)
                 .collect(),
         )
-        .unwrap();
+        .expect("Failed to create matrix");
 
         let vector = Vector::from_slice(
             &(0..cols)
@@ -35,7 +35,7 @@ fn main() {
 
         // Warmup
         for _ in 0..3 {
-            let _ = matrix.matvec(&vector).unwrap();
+            let _ = matrix.matvec(&vector).expect("Warmup matvec failed");
         }
 
         // Benchmark
@@ -43,7 +43,7 @@ fn main() {
         let start = Instant::now();
 
         for _ in 0..iterations {
-            let _ = matrix.matvec(&vector).unwrap();
+            let _ = matrix.matvec(&vector).expect("Benchmark matvec failed");
         }
 
         let elapsed = start.elapsed();

--- a/examples/benchmark_parallel.rs
+++ b/examples/benchmark_parallel.rs
@@ -12,7 +12,7 @@ fn main() {
             .map(|i| ((i % 100) as f32) / 10.0)
             .collect(),
     )
-    .unwrap();
+    .expect("Failed to create matrix A");
 
     let b = Matrix::from_vec(
         size,
@@ -21,12 +21,12 @@ fn main() {
             .map(|i| (((i * 7) % 100) as f32) / 10.0)
             .collect(),
     )
-    .unwrap();
+    .expect("Failed to create matrix B");
 
     // Warmup
     println!("Warmup...");
     for _ in 0..3 {
-        let _ = a.matmul(&b).unwrap();
+        let _ = a.matmul(&b).expect("Warmup matmul failed");
     }
 
     // Benchmark
@@ -35,7 +35,7 @@ fn main() {
     let start = Instant::now();
 
     for _ in 0..iterations {
-        let _ = a.matmul(&b).unwrap();
+        let _ = a.matmul(&b).expect("Benchmark matmul failed");
     }
 
     let elapsed = start.elapsed();

--- a/src/backends/gpu/batch.rs
+++ b/src/backends/gpu/batch.rs
@@ -92,28 +92,16 @@ enum GpuOp {
     },
 
     /// Sigmoid activation: 1 / (1 + exp(-x))
-    Sigmoid {
-        input: BufferId,
-        output: BufferId,
-    },
+    Sigmoid { input: BufferId, output: BufferId },
 
     /// Hyperbolic tangent: tanh(x)
-    Tanh {
-        input: BufferId,
-        output: BufferId,
-    },
+    Tanh { input: BufferId, output: BufferId },
 
     /// Swish activation: x * sigmoid(x)
-    Swish {
-        input: BufferId,
-        output: BufferId,
-    },
+    Swish { input: BufferId, output: BufferId },
 
     /// GELU activation: x * Φ(x) where Φ is cumulative distribution function
-    Gelu {
-        input: BufferId,
-        output: BufferId,
-    },
+    Gelu { input: BufferId, output: BufferId },
 
     /// Element-wise subtraction: a - b
     Sub {
@@ -191,9 +179,7 @@ impl GpuCommandBatch {
     ///
     /// Returns buffer ID for the output.
     pub fn relu(&mut self, input: BufferId) -> BufferId {
-        let size = self.buffers.get(&input)
-            .expect("Invalid buffer ID")
-            .size;
+        let size = self.buffers.get(&input).expect("Invalid buffer ID").size;
 
         let output = self.alloc_output(size);
 
@@ -206,9 +192,7 @@ impl GpuCommandBatch {
     ///
     /// Returns buffer ID for the output.
     pub fn scale(&mut self, input: BufferId, scalar: f32) -> BufferId {
-        let size = self.buffers.get(&input)
-            .expect("Invalid buffer ID")
-            .size;
+        let size = self.buffers.get(&input).expect("Invalid buffer ID").size;
 
         let output = self.alloc_output(size);
 
@@ -297,9 +281,7 @@ impl GpuCommandBatch {
     ///
     /// Returns buffer ID for the output.
     pub fn sigmoid(&mut self, input: BufferId) -> BufferId {
-        let size = self.buffers.get(&input)
-            .expect("Invalid buffer ID")
-            .size;
+        let size = self.buffers.get(&input).expect("Invalid buffer ID").size;
 
         let output = self.alloc_output(size);
 
@@ -312,9 +294,7 @@ impl GpuCommandBatch {
     ///
     /// Returns buffer ID for the output.
     pub fn tanh(&mut self, input: BufferId) -> BufferId {
-        let size = self.buffers.get(&input)
-            .expect("Invalid buffer ID")
-            .size;
+        let size = self.buffers.get(&input).expect("Invalid buffer ID").size;
 
         let output = self.alloc_output(size);
 
@@ -327,9 +307,7 @@ impl GpuCommandBatch {
     ///
     /// Returns buffer ID for the output.
     pub fn swish(&mut self, input: BufferId) -> BufferId {
-        let size = self.buffers.get(&input)
-            .expect("Invalid buffer ID")
-            .size;
+        let size = self.buffers.get(&input).expect("Invalid buffer ID").size;
 
         let output = self.alloc_output(size);
 
@@ -342,9 +320,7 @@ impl GpuCommandBatch {
     ///
     /// Returns buffer ID for the output.
     pub fn gelu(&mut self, input: BufferId) -> BufferId {
-        let size = self.buffers.get(&input)
-            .expect("Invalid buffer ID")
-            .size;
+        let size = self.buffers.get(&input).expect("Invalid buffer ID").size;
 
         let output = self.alloc_output(size);
 
@@ -388,17 +364,14 @@ impl GpuCommandBatch {
         for (buffer_id, buffer_info) in &mut self.buffers {
             let size_bytes = (buffer_info.size * std::mem::size_of::<f32>()) as u64;
 
-            let gpu_buffer = self
-                .device
-                .device
-                .create_buffer(&wgpu::BufferDescriptor {
-                    label: Some(&format!("Buffer {:?}", buffer_id)),
-                    size: size_bytes,
-                    usage: wgpu::BufferUsages::STORAGE
-                        | wgpu::BufferUsages::COPY_SRC
-                        | wgpu::BufferUsages::COPY_DST,
-                    mapped_at_creation: false,
-                });
+            let gpu_buffer = self.device.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(&format!("Buffer {:?}", buffer_id)),
+                size: size_bytes,
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_SRC
+                    | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
 
             buffer_info.gpu_buffer = Some(gpu_buffer);
         }
@@ -428,14 +401,8 @@ impl GpuCommandBatch {
 
         match op {
             GpuOp::Relu { input, output } => {
-                let input_info = self
-                    .buffers
-                    .get(input)
-                    .ok_or("Invalid input buffer ID")?;
-                let output_info = self
-                    .buffers
-                    .get(output)
-                    .ok_or("Invalid output buffer ID")?;
+                let input_info = self.buffers.get(input).ok_or("Invalid input buffer ID")?;
+                let output_info = self.buffers.get(output).ok_or("Invalid output buffer ID")?;
 
                 let input_buffer = input_info
                     .gpu_buffer
@@ -462,14 +429,8 @@ impl GpuCommandBatch {
                 output,
                 scalar,
             } => {
-                let input_info = self
-                    .buffers
-                    .get(input)
-                    .ok_or("Invalid input buffer ID")?;
-                let output_info = self
-                    .buffers
-                    .get(output)
-                    .ok_or("Invalid output buffer ID")?;
+                let input_info = self.buffers.get(input).ok_or("Invalid input buffer ID")?;
+                let output_info = self.buffers.get(output).ok_or("Invalid output buffer ID")?;
 
                 let input_buffer = input_info
                     .gpu_buffer
@@ -507,10 +468,7 @@ impl GpuCommandBatch {
             GpuOp::Add { a, b, output } => {
                 let a_info = self.buffers.get(a).ok_or("Invalid buffer A ID")?;
                 let b_info = self.buffers.get(b).ok_or("Invalid buffer B ID")?;
-                let output_info = self
-                    .buffers
-                    .get(output)
-                    .ok_or("Invalid output buffer ID")?;
+                let output_info = self.buffers.get(output).ok_or("Invalid output buffer ID")?;
 
                 let a_buffer = a_info.gpu_buffer.as_ref().ok_or("Buffer A not created")?;
                 let b_buffer = b_info.gpu_buffer.as_ref().ok_or("Buffer B not created")?;
@@ -533,10 +491,7 @@ impl GpuCommandBatch {
             GpuOp::Mul { a, b, output } => {
                 let a_info = self.buffers.get(a).ok_or("Invalid buffer A ID")?;
                 let b_info = self.buffers.get(b).ok_or("Invalid buffer B ID")?;
-                let output_info = self
-                    .buffers
-                    .get(output)
-                    .ok_or("Invalid output buffer ID")?;
+                let output_info = self.buffers.get(output).ok_or("Invalid output buffer ID")?;
 
                 let a_buffer = a_info.gpu_buffer.as_ref().ok_or("Buffer A not created")?;
                 let b_buffer = b_info.gpu_buffer.as_ref().ok_or("Buffer B not created")?;
@@ -559,10 +514,7 @@ impl GpuCommandBatch {
             GpuOp::Dot { a, b, output } => {
                 let a_info = self.buffers.get(a).ok_or("Invalid buffer A ID")?;
                 let b_info = self.buffers.get(b).ok_or("Invalid buffer B ID")?;
-                let output_info = self
-                    .buffers
-                    .get(output)
-                    .ok_or("Invalid output buffer ID")?;
+                let output_info = self.buffers.get(output).ok_or("Invalid output buffer ID")?;
 
                 let a_buffer = a_info.gpu_buffer.as_ref().ok_or("Buffer A not created")?;
                 let b_buffer = b_info.gpu_buffer.as_ref().ok_or("Buffer B not created")?;
@@ -583,14 +535,8 @@ impl GpuCommandBatch {
             }
 
             GpuOp::Sigmoid { input, output } => {
-                let input_info = self
-                    .buffers
-                    .get(input)
-                    .ok_or("Invalid input buffer ID")?;
-                let output_info = self
-                    .buffers
-                    .get(output)
-                    .ok_or("Invalid output buffer ID")?;
+                let input_info = self.buffers.get(input).ok_or("Invalid input buffer ID")?;
+                let output_info = self.buffers.get(output).ok_or("Invalid output buffer ID")?;
 
                 let input_buffer = input_info
                     .gpu_buffer
@@ -613,14 +559,8 @@ impl GpuCommandBatch {
             }
 
             GpuOp::Tanh { input, output } => {
-                let input_info = self
-                    .buffers
-                    .get(input)
-                    .ok_or("Invalid input buffer ID")?;
-                let output_info = self
-                    .buffers
-                    .get(output)
-                    .ok_or("Invalid output buffer ID")?;
+                let input_info = self.buffers.get(input).ok_or("Invalid input buffer ID")?;
+                let output_info = self.buffers.get(output).ok_or("Invalid output buffer ID")?;
 
                 let input_buffer = input_info
                     .gpu_buffer
@@ -643,14 +583,8 @@ impl GpuCommandBatch {
             }
 
             GpuOp::Swish { input, output } => {
-                let input_info = self
-                    .buffers
-                    .get(input)
-                    .ok_or("Invalid input buffer ID")?;
-                let output_info = self
-                    .buffers
-                    .get(output)
-                    .ok_or("Invalid output buffer ID")?;
+                let input_info = self.buffers.get(input).ok_or("Invalid input buffer ID")?;
+                let output_info = self.buffers.get(output).ok_or("Invalid output buffer ID")?;
 
                 let input_buffer = input_info
                     .gpu_buffer
@@ -673,14 +607,8 @@ impl GpuCommandBatch {
             }
 
             GpuOp::Gelu { input, output } => {
-                let input_info = self
-                    .buffers
-                    .get(input)
-                    .ok_or("Invalid input buffer ID")?;
-                let output_info = self
-                    .buffers
-                    .get(output)
-                    .ok_or("Invalid output buffer ID")?;
+                let input_info = self.buffers.get(input).ok_or("Invalid input buffer ID")?;
+                let output_info = self.buffers.get(output).ok_or("Invalid output buffer ID")?;
 
                 let input_buffer = input_info
                     .gpu_buffer
@@ -705,10 +633,7 @@ impl GpuCommandBatch {
             GpuOp::Sub { a, b, output } => {
                 let a_info = self.buffers.get(a).ok_or("Invalid buffer A ID")?;
                 let b_info = self.buffers.get(b).ok_or("Invalid buffer B ID")?;
-                let output_info = self
-                    .buffers
-                    .get(output)
-                    .ok_or("Invalid output buffer ID")?;
+                let output_info = self.buffers.get(output).ok_or("Invalid output buffer ID")?;
 
                 let a_buffer = a_info.gpu_buffer.as_ref().ok_or("Buffer A not created")?;
                 let b_buffer = b_info.gpu_buffer.as_ref().ok_or("Buffer B not created")?;
@@ -854,25 +779,25 @@ impl GpuCommandBatch {
                     push_constant_ranges: &[],
                 });
 
-        let pipeline = self
-            .device
-            .device
-            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-                label: Some(&format!("{} Pipeline", label)),
-                layout: Some(&pipeline_layout),
-                module: &shader,
-                entry_point: Some("main"),
-                compilation_options: Default::default(),
-                cache: None,
-            });
+        let pipeline =
+            self.device
+                .device
+                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                    label: Some(&format!("{} Pipeline", label)),
+                    layout: Some(&pipeline_layout),
+                    module: &shader,
+                    entry_point: Some("main"),
+                    compilation_options: Default::default(),
+                    cache: None,
+                });
 
         // Execute
-        let mut encoder = self
-            .device
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some(&format!("{} Encoder", label)),
-            });
+        let mut encoder =
+            self.device
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some(&format!("{} Encoder", label)),
+                });
 
         {
             let mut compute_pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
@@ -985,25 +910,25 @@ impl GpuCommandBatch {
                     push_constant_ranges: &[],
                 });
 
-        let pipeline = self
-            .device
-            .device
-            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-                label: Some(&format!("{} Pipeline", label)),
-                layout: Some(&pipeline_layout),
-                module: &shader,
-                entry_point: Some("main"),
-                compilation_options: Default::default(),
-                cache: None,
-            });
+        let pipeline =
+            self.device
+                .device
+                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                    label: Some(&format!("{} Pipeline", label)),
+                    layout: Some(&pipeline_layout),
+                    module: &shader,
+                    entry_point: Some("main"),
+                    compilation_options: Default::default(),
+                    cache: None,
+                });
 
         // Execute
-        let mut encoder = self
-            .device
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some(&format!("{} Encoder", label)),
-            });
+        let mut encoder =
+            self.device
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some(&format!("{} Encoder", label)),
+                });
 
         {
             let mut compute_pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
@@ -1029,10 +954,7 @@ impl GpuCommandBatch {
     ///
     /// Must call `execute()` first.
     pub async fn read(&self, buffer_id: BufferId) -> Result<Vec<f32>, String> {
-        let buffer_info = self
-            .buffers
-            .get(&buffer_id)
-            .ok_or("Invalid buffer ID")?;
+        let buffer_info = self.buffers.get(&buffer_id).ok_or("Invalid buffer ID")?;
 
         let gpu_buffer = buffer_info
             .gpu_buffer
@@ -1042,23 +964,20 @@ impl GpuCommandBatch {
         let size_bytes = (buffer_info.size * std::mem::size_of::<f32>()) as u64;
 
         // Create staging buffer for reading
-        let staging_buffer = self
-            .device
-            .device
-            .create_buffer(&wgpu::BufferDescriptor {
-                label: Some("Staging Buffer"),
-                size: size_bytes,
-                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
-                mapped_at_creation: false,
-            });
+        let staging_buffer = self.device.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Staging Buffer"),
+            size: size_bytes,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
 
         // Copy from GPU buffer to staging buffer
-        let mut encoder = self
-            .device
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("Read Encoder"),
-            });
+        let mut encoder =
+            self.device
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("Read Encoder"),
+                });
 
         encoder.copy_buffer_to_buffer(gpu_buffer, 0, &staging_buffer, 0, size_bytes);
 
@@ -1287,7 +1206,7 @@ mod tests {
         // sigmoid(-2) ≈ 0.119, sigmoid(0) = 0.5, sigmoid(2) ≈ 0.881
         assert_eq!(result.len(), 5);
         assert!((result[0] - 0.119).abs() < 0.01); // -2
-        assert!((result[2] - 0.5).abs() < 0.01);   // 0
+        assert!((result[2] - 0.5).abs() < 0.01); // 0
         assert!((result[4] - 0.881).abs() < 0.01); // 2
     }
 

--- a/src/backends/gpu/device.rs
+++ b/src/backends/gpu/device.rs
@@ -292,10 +292,12 @@ impl GpuDevice {
         });
 
         // Poll device to ensure GPU work completes and callbacks are invoked
-        self.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        }).ok();
+        self.device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .ok();
 
         receiver
             .receive()
@@ -488,10 +490,12 @@ impl GpuDevice {
         });
 
         // Poll device to ensure GPU work completes and callbacks are invoked
-        self.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        }).ok();
+        self.device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .ok();
 
         receiver
             .receive()
@@ -716,10 +720,12 @@ impl GpuDevice {
         });
 
         // Poll device to ensure GPU work completes and callbacks are invoked
-        self.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        }).ok();
+        self.device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .ok();
 
         receiver
             .receive()
@@ -1078,10 +1084,12 @@ impl GpuDevice {
         });
 
         // Poll device to ensure GPU work completes and callbacks are invoked
-        self.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        }).ok();
+        self.device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .ok();
         receiver
             .receive()
             .await
@@ -1233,10 +1241,12 @@ impl GpuDevice {
         });
 
         // Poll device to ensure GPU work completes and callbacks are invoked
-        self.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        }).ok();
+        self.device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .ok();
         receiver
             .receive()
             .await
@@ -1480,10 +1490,12 @@ impl GpuDevice {
         });
 
         // Poll device to ensure GPU work completes and callbacks are invoked
-        self.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        }).ok();
+        self.device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .ok();
 
         receiver
             .receive()
@@ -1771,10 +1783,12 @@ impl GpuDevice {
         });
 
         // Poll device to ensure GPU work completes and callbacks are invoked
-        self.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        }).ok();
+        self.device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .ok();
 
         receiver
             .receive()

--- a/tests/golden_trace_validation.rs
+++ b/tests/golden_trace_validation.rs
@@ -158,8 +158,16 @@ fn test_golden_traces_valid_json() {
             .unwrap_or_else(|e| panic!("Invalid JSON in {}: {}", trace_path, e));
 
         // Validate required fields exist
-        assert!(parsed.get("version").is_some(), "Missing 'version' in {}", trace_path);
-        assert!(parsed.get("format").is_some(), "Missing 'format' in {}", trace_path);
+        assert!(
+            parsed.get("version").is_some(),
+            "Missing 'version' in {}",
+            trace_path
+        );
+        assert!(
+            parsed.get("format").is_some(),
+            "Missing 'format' in {}",
+            trace_path
+        );
 
         // Validate format is correct
         if let Some(format) = parsed.get("format") {
@@ -213,12 +221,14 @@ fn test_golden_trace_analysis_exists() {
         "Golden trace analysis documentation missing"
     );
 
-    let content = std::fs::read_to_string(analysis_path)
-        .expect("Failed to read ANALYSIS.md");
+    let content = std::fs::read_to_string(analysis_path).expect("Failed to read ANALYSIS.md");
 
     // Validate documentation contains key sections
     assert!(content.contains("## Overview"), "Missing Overview section");
-    assert!(content.contains("## Baseline Performance Metrics"), "Missing performance metrics");
+    assert!(
+        content.contains("## Baseline Performance Metrics"),
+        "Missing performance metrics"
+    );
     assert!(content.contains("SIMD"), "Missing SIMD documentation");
 }
 
@@ -233,11 +243,26 @@ fn test_performance_budgets_documented() {
     let content = std::fs::read_to_string(analysis_path).unwrap();
 
     // Check that all examples have documented budgets
-    assert!(content.contains("backend_detection"), "Missing backend_detection budget");
-    assert!(content.contains("matrix_operations"), "Missing matrix_operations budget");
-    assert!(content.contains("activation_functions"), "Missing activation_functions budget");
-    assert!(content.contains("performance_demo"), "Missing performance_demo budget");
-    assert!(content.contains("ml_similarity"), "Missing ml_similarity budget");
+    assert!(
+        content.contains("backend_detection"),
+        "Missing backend_detection budget"
+    );
+    assert!(
+        content.contains("matrix_operations"),
+        "Missing matrix_operations budget"
+    );
+    assert!(
+        content.contains("activation_functions"),
+        "Missing activation_functions budget"
+    );
+    assert!(
+        content.contains("performance_demo"),
+        "Missing performance_demo budget"
+    );
+    assert!(
+        content.contains("ml_similarity"),
+        "Missing ml_similarity budget"
+    );
 
     // Check that performance budget compliance is documented
     assert!(


### PR DESCRIPTION
PMAT quality gate fixes:
- Replace all .unwrap() calls with .expect() with descriptive messages
- Apply cargo fmt to fix code formatting issues
- All quality gates now passing:
  * Coverage: 90.45% (≥90% ✅)
  * PMAT TDG: 86.6/100 (A-) (≥B+ ✅)
  * Clippy: 0 warnings ✅
  * No critical defects ✅

Changes:
- examples/benchmark_parallel.rs: Replace unwrap with expect
- examples/benchmark_matvec_parallel.rs: Replace unwrap with expect
- examples/benchmark_matvec.rs: Replace unwrap with expect
- examples/benchmark_matrix_suite.rs: Replace unwrap with expect
- Multiple files: Apply cargo fmt formatting

This resolves all PMAT critical defects that were blocking quality gates. Examples now use proper error handling with descriptive messages.