### PR TITLE
chore: Add benchmark_run.log to gitignore

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -13,3 +13,4 @@ venv/
 python_results.json
 comparison_report.md
 comparison_summary.json
+benchmark_run.log


### PR DESCRIPTION
- Added benchmark_run.log to benchmarks/.gitignore
- This file is generated during benchmark runs and should not be tracked