### PR TITLE
chore: Add direct_bench.log to gitignore

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -14,3 +14,4 @@ python_results.json
 comparison_report.md
 comparison_summary.json
 benchmark_run.log
+direct_bench.log


### PR DESCRIPTION
- Added direct_bench.log to benchmarks/.gitignore
- This file is generated during direct cargo bench runs