### PR TITLE
perf: GPU batch infrastructure — KAIZEN-015/021/022/023/025

### DIFF
--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "3.6.1",
-  "created_at": "2026-03-04T09:30:30.553593036Z",
+  "created_at": "2026-03-04T09:32:26.645784589Z",
   "git_context": null,
   "files": {},
   "summary": {

--- a/src/blis/parallel.rs
+++ b/src/blis/parallel.rs
@@ -7,9 +7,7 @@ use crate::error::TruenoError;
 
 use super::compute::gemm_blis;
 #[cfg(feature = "parallel")]
-use super::packing::packed_b_size;
-#[cfg(feature = "parallel")]
-use super::{KC, MC, NC, NR};
+use super::MC;
 
 /// Heijunka (load-leveling) scheduler for parallel GEMM
 #[derive(Debug, Clone)]
@@ -87,15 +85,12 @@ pub fn gemm_blis_parallel(
     let scheduler = HeijunkaScheduler::default();
     let partitions = scheduler.partition_m(m, MC);
 
-    // Pack B once (shared across threads)
-    let nc = NC.min(n);
-    let kc = KC.min(k);
-    let packed_b_total_size = ((n + NR - 1) / NR) * ((k + KC - 1) / KC) * packed_b_size(kc, nc);
-    let _packed_b = std::sync::Arc::new(std::sync::RwLock::new(vec![0.0f32; packed_b_total_size]));
+    // KAIZEN-042: Removed dead packed_b allocation that was never used.
+    // Each thread packs B internally via gemm_blis. Sharing packed B across
+    // threads would require refactoring gemm_blis to accept pre-packed input.
 
     // Parallel over M partitions
     let c_ptr = c.as_mut_ptr() as usize;
-    let _c_len = c.len();
 
     partitions.into_par_iter().for_each(|m_range| {
         let m_local = m_range.len();


### PR DESCRIPTION
## Summary

- **KAIZEN-015**: `import_buffer()` for GPU-resident buffers — skip re-upload of frozen weights
- **KAIZEN-021**: Tiled shared-memory matmul WGSL shader — 16× memory bandwidth reduction via 16×16 tiles
- **KAIZEN-022**: Pipeline cache + single command encoder per batch — one GPU submission instead of N
- **KAIZEN-023**: Public `PipelineCache` + `execute_with_cache()` — cross-batch shader reuse (3 compilations total vs 108 for 36-layer model)
- **KAIZEN-025**: Dead code cleanup — removed unused `imported` field, narrowed dispatch visibility

## Impact

For Qwen3-4B FFN (36 layers, 3 unique shaders):
- **Before**: 108 shader compilations + 108 GPU submissions + weight re-upload every batch
- **After**: 3 compilations (first batch only) + 1 submission + zero re-upload (GPU-resident)

## Test plan

- [x] `cargo test --lib` — 3338 tests pass
- [x] `cargo test --lib --features gpu` — 3390 tests pass (52 GPU-specific)
- [x] `cargo check --features gpu` — clean compile
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)