### PR TITLE
style: cargo fmt (unified CI prep)

### DIFF
--- a/crates/trueno-fft/benches/fft_bench.rs
+++ b/crates/trueno-fft/benches/fft_bench.rs
@@ -5,12 +5,8 @@ fn bench_fft_forward(c: &mut Criterion) {
     let mut group = c.benchmark_group("fft_forward");
     for &n in &[64, 256, 1024, 4096] {
         let plan = FftPlan::new(n).expect("valid plan");
-        let input: Vec<Complex> = (0..n)
-            .map(|i| Complex {
-                re: (i as f32).sin(),
-                im: 0.0,
-            })
-            .collect();
+        let input: Vec<Complex> =
+            (0..n).map(|i| Complex { re: (i as f32).sin(), im: 0.0 }).collect();
         let mut output = vec![Complex { re: 0.0, im: 0.0 }; n];
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
             b.iter(|| {
@@ -26,17 +22,12 @@ fn bench_fft_inverse(c: &mut Criterion) {
     let mut group = c.benchmark_group("fft_inverse");
     for &n in &[64, 256, 1024] {
         let plan = FftPlan::new(n).expect("valid plan");
-        let input: Vec<Complex> = (0..n)
-            .map(|i| Complex {
-                re: (i as f32).cos(),
-                im: (i as f32).sin(),
-            })
-            .collect();
+        let input: Vec<Complex> =
+            (0..n).map(|i| Complex { re: (i as f32).cos(), im: (i as f32).sin() }).collect();
         let mut output = vec![Complex { re: 0.0, im: 0.0 }; n];
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
             b.iter(|| {
-                plan.inverse(black_box(&input), &mut output)
-                    .expect("ifft ok");
+                plan.inverse(black_box(&input), &mut output).expect("ifft ok");
                 black_box(&output);
             });
         });
@@ -52,8 +43,7 @@ fn bench_fft_r2c(c: &mut Criterion) {
         let mut output = vec![Complex { re: 0.0, im: 0.0 }; n / 2 + 1];
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
             b.iter(|| {
-                plan.forward_r2c(black_box(&input), &mut output)
-                    .expect("r2c ok");
+                plan.forward_r2c(black_box(&input), &mut output).expect("r2c ok");
                 black_box(&output);
             });
         });

--- a/crates/trueno-fft/examples/fft_demo.rs
+++ b/crates/trueno-fft/examples/fft_demo.rs
@@ -27,9 +27,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Roundtrip
     let mut recovered = vec![Complex::ZERO; 8];
     plan.inverse(&output, &mut recovered)?;
-    let max_err: f32 = input.iter().zip(recovered.iter())
-        .map(|(a, b)| (*a - *b).abs())
-        .fold(0.0f32, f32::max);
+    let max_err: f32 =
+        input.iter().zip(recovered.iter()).map(|(a, b)| (*a - *b).abs()).fold(0.0f32, f32::max);
     println!("Roundtrip max error: {max_err:.2e}");
 
     // ── Bluestein (arbitrary length) ───────────────────────
@@ -45,39 +44,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Bluestein roundtrip
     let mut rec5 = vec![Complex::ZERO; 5];
     bluestein_fft(&output5, &mut rec5, true)?;
-    let err5: f32 = input5.iter().zip(rec5.iter())
-        .map(|(a, b)| (*a - *b).abs())
-        .fold(0.0f32, f32::max);
+    let err5: f32 =
+        input5.iter().zip(rec5.iter()).map(|(a, b)| (*a - *b).abs()).fold(0.0f32, f32::max);
     println!("Bluestein roundtrip error: {err5:.2e}");
 
     // ── 3D FFT ─────────────────────────────────────────────
     println!("\n--- 3D FFT ---");
     let (nx, ny, nz) = (2, 4, 2);
     let total = nx * ny * nz;
-    let input3d: Vec<Complex> = (0..total)
-        .map(|i| Complex::new((i as f32).sin(), (i as f32).cos()))
-        .collect();
+    let input3d: Vec<Complex> =
+        (0..total).map(|i| Complex::new((i as f32).sin(), (i as f32).cos())).collect();
     let mut freq3d = vec![Complex::ZERO; total];
     let mut rec3d = vec![Complex::ZERO; total];
     fft_3d(&input3d, &mut freq3d, nx, ny, nz)?;
     ifft_3d(&freq3d, &mut rec3d, nx, ny, nz)?;
-    let err3d: f32 = input3d.iter().zip(rec3d.iter())
-        .map(|(a, b)| (*a - *b).abs())
-        .fold(0.0f32, f32::max);
+    let err3d: f32 =
+        input3d.iter().zip(rec3d.iter()).map(|(a, b)| (*a - *b).abs()).fold(0.0f32, f32::max);
     println!("3D FFT {nx}×{ny}×{nz} roundtrip error: {err3d:.2e}");
 
     // ── Batched FFT ────────────────────────────────────────
     println!("\n--- Batched FFT ---");
     let n = 4;
     let batch = 3;
-    let batch_input: Vec<Complex> = (0..n * batch)
-        .map(|i| Complex::new(i as f32, 0.0))
-        .collect();
+    let batch_input: Vec<Complex> = (0..n * batch).map(|i| Complex::new(i as f32, 0.0)).collect();
     let mut batch_freq = vec![Complex::ZERO; n * batch];
     let mut batch_rec = vec![Complex::ZERO; n * batch];
     fft_batched(&batch_input, &mut batch_freq, n, batch, false)?;
     fft_batched(&batch_freq, &mut batch_rec, n, batch, true)?;
-    let err_batch: f32 = batch_input.iter().zip(batch_rec.iter())
+    let err_batch: f32 = batch_input
+        .iter()
+        .zip(batch_rec.iter())
         .map(|(a, b)| (*a - *b).abs())
         .fold(0.0f32, f32::max);
     println!("{batch} batches of size {n}: roundtrip error = {err_batch:.2e}");
@@ -92,9 +88,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // C2R roundtrip
     let mut c2r_out = vec![0.0f32; 8];
     fft_c2r(&r2c_out, &mut c2r_out, 8)?;
-    let c2r_err: f32 = real_input.iter().zip(c2r_out.iter())
-        .map(|(a, b)| (a - b).abs())
-        .fold(0.0f32, f32::max);
+    let c2r_err: f32 =
+        real_input.iter().zip(c2r_out.iter()).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
     println!("R2C → C2R roundtrip error: {c2r_err:.2e}");
 
     println!("\n=== All FFT demos passed ===");

--- a/crates/trueno-fft/src/bluestein.rs
+++ b/crates/trueno-fft/src/bluestein.rs
@@ -31,10 +31,7 @@ pub fn bluestein_fft(
         return Err(FftError::ZeroLength);
     }
     if output.len() != n {
-        return Err(FftError::OutputLengthMismatch {
-            expected: n,
-            got: output.len(),
-        });
+        return Err(FftError::OutputLengthMismatch { expected: n, got: output.len() });
     }
 
     // For power-of-two sizes, delegate directly

--- a/crates/trueno-fft/src/complex.rs
+++ b/crates/trueno-fft/src/complex.rs
@@ -36,28 +36,19 @@ impl Complex {
     /// Complex conjugate.
     #[inline]
     pub fn conj(self) -> Self {
-        Self {
-            re: self.re,
-            im: -self.im,
-        }
+        Self { re: self.re, im: -self.im }
     }
 
     /// Create from polar form: r * e^(iθ).
     #[inline]
     pub fn from_polar(r: f32, theta: f32) -> Self {
-        Self {
-            re: r * theta.cos(),
-            im: r * theta.sin(),
-        }
+        Self { re: r * theta.cos(), im: r * theta.sin() }
     }
 
     /// Scale by a real number.
     #[inline]
     pub fn scale(self, s: f32) -> Self {
-        Self {
-            re: self.re * s,
-            im: self.im * s,
-        }
+        Self { re: self.re * s, im: self.im * s }
     }
 }
 
@@ -65,10 +56,7 @@ impl Add for Complex {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            re: self.re + rhs.re,
-            im: self.im + rhs.im,
-        }
+        Self { re: self.re + rhs.re, im: self.im + rhs.im }
     }
 }
 
@@ -76,10 +64,7 @@ impl Sub for Complex {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            re: self.re - rhs.re,
-            im: self.im - rhs.im,
-        }
+        Self { re: self.re - rhs.re, im: self.im - rhs.im }
     }
 }
 
@@ -87,9 +72,6 @@ impl Mul for Complex {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            re: self.re * rhs.re - self.im * rhs.im,
-            im: self.re * rhs.im + self.im * rhs.re,
-        }
+        Self { re: self.re * rhs.re - self.im * rhs.im, im: self.re * rhs.im + self.im * rhs.re }
     }
 }

--- a/crates/trueno-fft/src/fft3d.rs
+++ b/crates/trueno-fft/src/fft3d.rs
@@ -90,20 +90,10 @@ fn validate_3d(
         return Err(FftError::ZeroLength);
     }
     if in_len != total {
-        return Err(FftError::DimensionMismatch3d {
-            len: in_len,
-            nx,
-            ny,
-            nz,
-        });
+        return Err(FftError::DimensionMismatch3d { len: in_len, nx, ny, nz });
     }
     if out_len != total {
-        return Err(FftError::DimensionMismatch3d {
-            len: out_len,
-            nx,
-            ny,
-            nz,
-        });
+        return Err(FftError::DimensionMismatch3d { len: out_len, nx, ny, nz });
     }
     Ok(())
 }
@@ -216,16 +206,10 @@ pub fn fft_batched(
 ) -> Result<(), FftError> {
     let total = n * batch_count;
     if input.len() != total {
-        return Err(FftError::OutputLengthMismatch {
-            expected: total,
-            got: input.len(),
-        });
+        return Err(FftError::OutputLengthMismatch { expected: total, got: input.len() });
     }
     if output.len() != total {
-        return Err(FftError::OutputLengthMismatch {
-            expected: total,
-            got: output.len(),
-        });
+        return Err(FftError::OutputLengthMismatch { expected: total, got: output.len() });
     }
 
     let plan = FftPlan::new(n)?;

--- a/crates/trueno-fft/src/stockham.rs
+++ b/crates/trueno-fft/src/stockham.rs
@@ -51,11 +51,7 @@ impl FftPlan {
             }
         }
 
-        Ok(Self {
-            n,
-            log2_n,
-            twiddles,
-        })
+        Ok(Self { n, log2_n, twiddles })
     }
 
     /// Transform size.
@@ -102,10 +98,7 @@ impl FftPlan {
     /// Returns error on dimension mismatch.
     pub fn forward_r2c(&self, input: &[f32], output: &mut [Complex]) -> Result<(), FftError> {
         if input.len() != self.n {
-            return Err(FftError::OutputLengthMismatch {
-                expected: self.n,
-                got: input.len(),
-            });
+            return Err(FftError::OutputLengthMismatch { expected: self.n, got: input.len() });
         }
         let expected_out = self.n / 2 + 1;
         if output.len() != expected_out {
@@ -140,10 +133,7 @@ impl FftPlan {
             });
         }
         if output.len() != self.n {
-            return Err(FftError::OutputLengthMismatch {
-                expected: self.n,
-                got: output.len(),
-            });
+            return Err(FftError::OutputLengthMismatch { expected: self.n, got: output.len() });
         }
 
         // Reconstruct full N-point spectrum from Hermitian symmetry: X[N-k] = conj(X[k])
@@ -167,16 +157,10 @@ impl FftPlan {
 
     fn validate_buffers(&self, in_len: usize, out_len: usize) -> Result<(), FftError> {
         if in_len != self.n {
-            return Err(FftError::OutputLengthMismatch {
-                expected: self.n,
-                got: in_len,
-            });
+            return Err(FftError::OutputLengthMismatch { expected: self.n, got: in_len });
         }
         if out_len != self.n {
-            return Err(FftError::OutputLengthMismatch {
-                expected: self.n,
-                got: out_len,
-            });
+            return Err(FftError::OutputLengthMismatch { expected: self.n, got: out_len });
         }
         Ok(())
     }
@@ -207,11 +191,8 @@ impl FftPlan {
             while group_start < n {
                 for k in 0..half_size {
                     let tw_idx = k * tw_step;
-                    let tw = if inverse {
-                        self.twiddles[tw_idx].conj()
-                    } else {
-                        self.twiddles[tw_idx]
-                    };
+                    let tw =
+                        if inverse { self.twiddles[tw_idx].conj() } else { self.twiddles[tw_idx] };
 
                     let even_idx = group_start + k;
                     let odd_idx = even_idx + half_size;
@@ -273,18 +254,10 @@ pub fn fft_2d(
     ny: usize,
 ) -> Result<(), FftError> {
     if input.len() != nx * ny {
-        return Err(FftError::DimensionMismatch2d {
-            len: input.len(),
-            nx,
-            ny,
-        });
+        return Err(FftError::DimensionMismatch2d { len: input.len(), nx, ny });
     }
     if output.len() != nx * ny {
-        return Err(FftError::DimensionMismatch2d {
-            len: output.len(),
-            nx,
-            ny,
-        });
+        return Err(FftError::DimensionMismatch2d { len: output.len(), nx, ny });
     }
 
     let plan_x = FftPlan::new(nx)?;

--- a/crates/trueno-fft/src/tests.rs
+++ b/crates/trueno-fft/src/tests.rs
@@ -74,9 +74,8 @@ fn test_inverse_roundtrip_size_4() {
 #[test]
 fn test_inverse_roundtrip_size_16() {
     let plan = FftPlan::new(16).expect("valid plan");
-    let input: Vec<Complex> = (0..16)
-        .map(|i| Complex::new((i as f32).sin(), (i as f32).cos()))
-        .collect();
+    let input: Vec<Complex> =
+        (0..16).map(|i| Complex::new((i as f32).sin(), (i as f32).cos())).collect();
     let mut freq = vec![Complex::ZERO; 16];
     let mut recovered = vec![Complex::ZERO; 16];
 
@@ -85,10 +84,7 @@ fn test_inverse_roundtrip_size_16() {
 
     for (i, (orig, rec)) in input.iter().zip(recovered.iter()).enumerate() {
         let err = (*orig - *rec).abs();
-        assert!(
-            err < 1e-4,
-            "Roundtrip failed at index {i}: err={err}"
-        );
+        assert!(err < 1e-4, "Roundtrip failed at index {i}: err={err}");
     }
 }
 
@@ -125,11 +121,7 @@ fn test_dc_signal() {
     // FFT of constant = N*constant at k=0, zero elsewhere
     assert!((output[0].re - 12.0).abs() < 1e-5, "DC component wrong");
     for k in 1..4 {
-        assert!(
-            output[k].abs() < 1e-5,
-            "Non-DC component non-zero at k={k}: {:?}",
-            output[k]
-        );
+        assert!(output[k].abs() < 1e-5, "Non-DC component non-zero at k={k}: {:?}", output[k]);
     }
 }
 
@@ -141,19 +133,14 @@ fn test_dc_signal() {
 fn test_linearity() {
     let plan = FftPlan::new(8).expect("valid plan");
     let x: Vec<Complex> = (0..8).map(|i| Complex::new(i as f32, 0.0)).collect();
-    let y: Vec<Complex> = (0..8)
-        .map(|i| Complex::new(0.0, (i as f32).sin()))
-        .collect();
+    let y: Vec<Complex> = (0..8).map(|i| Complex::new(0.0, (i as f32).sin())).collect();
 
     let alpha = Complex::new(2.0, 0.0);
     let beta = Complex::new(0.5, 0.0);
 
     // FFT(α*x + β*y)
-    let combined: Vec<Complex> = x
-        .iter()
-        .zip(y.iter())
-        .map(|(&xi, &yi)| alpha * xi + beta * yi)
-        .collect();
+    let combined: Vec<Complex> =
+        x.iter().zip(y.iter()).map(|(&xi, &yi)| alpha * xi + beta * yi).collect();
     let mut fft_combined = vec![Complex::ZERO; 8];
     plan.forward(&combined, &mut fft_combined).expect("ok");
 
@@ -207,10 +194,7 @@ fn test_fft_2d_impulse() {
 
     // 2D impulse → all ones
     for (k, x) in output.iter().enumerate() {
-        assert!(
-            (x.re - 1.0).abs() < 1e-5 && x.im.abs() < 1e-5,
-            "2D impulse wrong at k={k}: {x:?}"
-        );
+        assert!((x.re - 1.0).abs() < 1e-5 && x.im.abs() < 1e-5, "2D impulse wrong at k={k}: {x:?}");
     }
 }
 
@@ -306,11 +290,7 @@ mod proptests {
 #[test]
 fn test_bluestein_size_3() -> Result<(), Box<dyn std::error::Error>> {
     // DFT of [1, 1, 1] size 3: X[0]=3, X[1]=X[2]=0
-    let input = [
-        Complex::new(1.0, 0.0),
-        Complex::new(1.0, 0.0),
-        Complex::new(1.0, 0.0),
-    ];
+    let input = [Complex::new(1.0, 0.0), Complex::new(1.0, 0.0), Complex::new(1.0, 0.0)];
     let mut output = [Complex::ZERO; 3];
     bluestein_fft(&input, &mut output, false)?;
     assert!((output[0].re - 3.0).abs() < 1e-3);
@@ -343,9 +323,7 @@ fn test_bluestein_size_5_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_bluestein_size_7_parseval() -> Result<(), Box<dyn std::error::Error>> {
-    let input: Vec<Complex> = (0..7)
-        .map(|i| Complex::new(i as f32, 0.0))
-        .collect();
+    let input: Vec<Complex> = (0..7).map(|i| Complex::new(i as f32, 0.0)).collect();
     let mut output = vec![Complex::ZERO; 7];
     bluestein_fft(&input, &mut output, false)?;
 
@@ -432,10 +410,7 @@ fn test_fft_3d_impulse() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3D impulse → all ones
     for (k, x) in output.iter().enumerate() {
-        assert!(
-            (x.re - 1.0).abs() < 1e-4 && x.im.abs() < 1e-4,
-            "3D impulse wrong at k={k}: {x:?}"
-        );
+        assert!((x.re - 1.0).abs() < 1e-4 && x.im.abs() < 1e-4, "3D impulse wrong at k={k}: {x:?}");
     }
     Ok(())
 }
@@ -444,9 +419,8 @@ fn test_fft_3d_impulse() -> Result<(), Box<dyn std::error::Error>> {
 fn test_fft_3d_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
     let (nx, ny, nz) = (2, 4, 2);
     let total = nx * ny * nz;
-    let input: Vec<Complex> = (0..total)
-        .map(|i| Complex::new((i as f32).sin(), (i as f32).cos()))
-        .collect();
+    let input: Vec<Complex> =
+        (0..total).map(|i| Complex::new((i as f32).sin(), (i as f32).cos())).collect();
     let mut freq = vec![Complex::ZERO; total];
     let mut recovered = vec![Complex::ZERO; total];
 
@@ -464,9 +438,7 @@ fn test_fft_3d_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
 fn test_fft_3d_parseval() -> Result<(), Box<dyn std::error::Error>> {
     let (nx, ny, nz) = (2, 2, 4);
     let total = nx * ny * nz;
-    let input: Vec<Complex> = (0..total)
-        .map(|i| Complex::new(i as f32, 0.0))
-        .collect();
+    let input: Vec<Complex> = (0..total).map(|i| Complex::new(i as f32, 0.0)).collect();
     let mut output = vec![Complex::ZERO; total];
 
     fft_3d(&input, &mut output, nx, ny, nz)?;
@@ -530,9 +502,7 @@ fn test_fft_batched_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
     let n = 8;
     let batch = 2;
     let total = n * batch;
-    let input: Vec<Complex> = (0..total)
-        .map(|i| Complex::new((i as f32).sin(), 0.0))
-        .collect();
+    let input: Vec<Complex> = (0..total).map(|i| Complex::new((i as f32).sin(), 0.0)).collect();
     let mut freq = vec![Complex::ZERO; total];
     let mut recovered = vec![Complex::ZERO; total];
 
@@ -721,9 +691,8 @@ fn test_fft_trait_2d_parseval() {
     let plan = FftPlan::new(4).expect("valid plan");
     let fft: &dyn Fft = &plan;
 
-    let input: Vec<Complex> = (0..16)
-        .map(|i| Complex::new((i as f32).sin(), (i as f32).cos()))
-        .collect();
+    let input: Vec<Complex> =
+        (0..16).map(|i| Complex::new((i as f32).sin(), (i as f32).cos())).collect();
     let mut output = vec![Complex::ZERO; 16];
 
     fft.fft_2d(&input, &mut output, 4, 4).expect("2d ok");
@@ -748,10 +717,7 @@ fn test_falsify_fft_all_zeros() {
     let mut output = vec![Complex::ZERO; 8];
     plan.forward(&input, &mut output).expect("fft ok");
     for (k, x) in output.iter().enumerate() {
-        assert!(
-            x.abs() < 1e-7,
-            "FFT of all zeros should be all zeros, got {x:?} at k={k}"
-        );
+        assert!(x.abs() < 1e-7, "FFT of all zeros should be all zeros, got {x:?} at k={k}");
     }
 }
 
@@ -795,20 +761,16 @@ fn test_falsify_fft_large_power_of_two() {
 fn test_falsify_fft_roundtrip_large() {
     let n = 256;
     let plan = FftPlan::new(n).expect("valid plan");
-    let input: Vec<Complex> = (0..n)
-        .map(|i| Complex::new((i as f32 * 0.1).sin(), (i as f32 * 0.07).cos()))
-        .collect();
+    let input: Vec<Complex> =
+        (0..n).map(|i| Complex::new((i as f32 * 0.1).sin(), (i as f32 * 0.07).cos())).collect();
     let mut freq = vec![Complex::ZERO; n];
     let mut recovered = vec![Complex::ZERO; n];
 
     plan.forward(&input, &mut freq).expect("ok");
     plan.inverse(&freq, &mut recovered).expect("ok");
 
-    let max_err = input
-        .iter()
-        .zip(recovered.iter())
-        .map(|(a, b)| (*a - *b).abs())
-        .fold(0.0_f32, f32::max);
+    let max_err =
+        input.iter().zip(recovered.iter()).map(|(a, b)| (*a - *b).abs()).fold(0.0_f32, f32::max);
     assert!(max_err < 1e-3, "Large roundtrip max error: {max_err}");
 }
 
@@ -835,20 +797,16 @@ fn test_falsify_bluestein_large_prime() -> Result<(), Box<dyn std::error::Error>
 #[test]
 fn test_falsify_bluestein_roundtrip_prime_23() -> Result<(), Box<dyn std::error::Error>> {
     let n = 23;
-    let input: Vec<Complex> = (0..n)
-        .map(|i| Complex::new((i as f32).sin(), (i as f32).cos()))
-        .collect();
+    let input: Vec<Complex> =
+        (0..n).map(|i| Complex::new((i as f32).sin(), (i as f32).cos())).collect();
     let mut freq = vec![Complex::ZERO; n];
     let mut recovered = vec![Complex::ZERO; n];
 
     bluestein_fft(&input, &mut freq, false)?;
     bluestein_fft(&freq, &mut recovered, true)?;
 
-    let max_err = input
-        .iter()
-        .zip(recovered.iter())
-        .map(|(a, b)| (*a - *b).abs())
-        .fold(0.0_f32, f32::max);
+    let max_err =
+        input.iter().zip(recovered.iter()).map(|(a, b)| (*a - *b).abs()).fold(0.0_f32, f32::max);
     assert!(max_err < 0.05, "Bluestein prime=23 roundtrip max error: {max_err}");
     Ok(())
 }
@@ -862,18 +820,10 @@ fn test_falsify_fft_2d_constant() {
     fft_2d(&input, &mut output, 4, 4).expect("ok");
 
     // DC = N*M*val = 16*3 = 48
-    assert!(
-        (output[0].re - 48.0).abs() < 1e-3,
-        "2D constant DC: {:?}",
-        output[0]
-    );
+    assert!((output[0].re - 48.0).abs() < 1e-3, "2D constant DC: {:?}", output[0]);
     // All other bins should be ~0
     for k in 1..16 {
-        assert!(
-            output[k].abs() < 1e-3,
-            "2D constant non-DC at k={k}: {:?}",
-            output[k]
-        );
+        assert!(output[k].abs() < 1e-3, "2D constant non-DC at k={k}: {:?}", output[k]);
     }
 }
 
@@ -888,11 +838,8 @@ fn test_falsify_r2c_c2r_roundtrip_large() -> Result<(), Box<dyn std::error::Erro
     plan.forward_r2c(&real_input, &mut freq)?;
     plan.inverse_c2r(&freq, &mut recovered)?;
 
-    let max_err = real_input
-        .iter()
-        .zip(recovered.iter())
-        .map(|(a, b)| (a - b).abs())
-        .fold(0.0_f32, f32::max);
+    let max_err =
+        real_input.iter().zip(recovered.iter()).map(|(a, b)| (a - b).abs()).fold(0.0_f32, f32::max);
     assert!(max_err < 1e-3, "R2C/C2R large roundtrip max error: {max_err}");
     Ok(())
 }

--- a/crates/trueno-image/benches/image_bench.rs
+++ b/crates/trueno-image/benches/image_bench.rs
@@ -2,9 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use trueno_image::{canny, conv2d, gaussian_blur, resize, BorderMode, Interpolation};
 
 fn make_image(w: usize, h: usize) -> Vec<f32> {
-    (0..w * h)
-        .map(|i| ((i * 13 + 7) % 256) as f32 / 255.0)
-        .collect()
+    (0..w * h).map(|i| ((i * 13 + 7) % 256) as f32 / 255.0).collect()
 }
 
 fn bench_conv2d(c: &mut Criterion) {
@@ -15,16 +13,8 @@ fn bench_conv2d(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
             b.iter(|| {
                 black_box(
-                    conv2d(
-                        black_box(&img),
-                        size,
-                        size,
-                        &kernel,
-                        3,
-                        3,
-                        BorderMode::Zero,
-                    )
-                    .expect("conv2d ok"),
+                    conv2d(black_box(&img), size, size, &kernel, 3, 3, BorderMode::Zero)
+                        .expect("conv2d ok"),
                 );
             });
         });
@@ -38,9 +28,7 @@ fn bench_gaussian_blur(c: &mut Criterion) {
         let img = make_image(size, size);
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
             b.iter(|| {
-                black_box(
-                    gaussian_blur(black_box(&img), size, size, 1.0).expect("blur ok"),
-                );
+                black_box(gaussian_blur(black_box(&img), size, size, 1.0).expect("blur ok"));
             });
         });
     }
@@ -53,9 +41,7 @@ fn bench_canny(c: &mut Criterion) {
         let img = make_image(size, size);
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
             b.iter(|| {
-                black_box(
-                    canny(black_box(&img), size, size, 1.0, 0.1, 0.3).expect("canny ok"),
-                );
+                black_box(canny(black_box(&img), size, size, 1.0, 0.1, 0.3).expect("canny ok"));
             });
         });
     }

--- a/crates/trueno-image/examples/image_demo.rs
+++ b/crates/trueno-image/examples/image_demo.rs
@@ -6,8 +6,8 @@
 
 use trueno_image::{
     canny, canny_rgb, connected_components, conv2d, dilate, equalize, erode, gaussian_blur,
-    gradient_magnitude, histogram, hsv_to_rgb, resize, rgb_to_gray, rgb_to_hsv, sobel,
-    BorderMode, ImageBuf, ImageOps, Interpolation,
+    gradient_magnitude, histogram, hsv_to_rgb, resize, rgb_to_gray, rgb_to_hsv, sobel, BorderMode,
+    ImageBuf, ImageOps, Interpolation,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -27,8 +27,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Convolution ────────────────────────────────────────
     let delta = [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0_f32];
     let id_out = conv2d(&image, w, h, &delta, 3, 3, BorderMode::Zero)?;
-    let conv_err: f32 = image.iter().zip(id_out.iter())
-        .map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+    let conv_err: f32 =
+        image.iter().zip(id_out.iter()).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
     println!("Identity conv max error: {conv_err:.2e}");
 
     // ── Gaussian blur ──────────────────────────────────────
@@ -85,13 +85,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         1.0, 1.0, 1.0_f32, // white
     ];
     let gray = rgb_to_gray(&rgb, 4, 1)?;
-    println!("RGB→Gray: red={:.3}, green={:.3}, blue={:.3}, white={:.3}",
-        gray[0], gray[1], gray[2], gray[3]);
+    println!(
+        "RGB→Gray: red={:.3}, green={:.3}, blue={:.3}, white={:.3}",
+        gray[0], gray[1], gray[2], gray[3]
+    );
 
     let hsv = rgb_to_hsv(&rgb, 4, 1)?;
     let recovered = hsv_to_rgb(&hsv, 4, 1)?;
-    let hsv_err: f32 = rgb.iter().zip(recovered.iter())
-        .map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+    let hsv_err: f32 =
+        rgb.iter().zip(recovered.iter()).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
     println!("RGB→HSV→RGB roundtrip error: {hsv_err:.2e}");
 
     // ── Connected components ───────────────────────────────
@@ -108,10 +110,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let num_labels = *labels.iter().max().unwrap_or(&0);
     println!("5×5 binary image → {num_labels} connected components");
     for y in 0..5 {
-        let row: String = (0..5).map(|x| {
-            let l = labels[y * 5 + x];
-            if l == 0 { '.' } else { (b'A' + (l - 1) as u8) as char }
-        }).collect();
+        let row: String = (0..5)
+            .map(|x| {
+                let l = labels[y * 5 + x];
+                if l == 0 {
+                    '.'
+                } else {
+                    (b'A' + (l - 1) as u8) as char
+                }
+            })
+            .collect();
         println!("  {row}");
     }
 
@@ -162,7 +170,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let resized = buf.apply_resize(8, 8, Interpolation::Bilinear)?;
     println!(
         "ImageBuf.apply_resize(8×8): {}×{} × {} ch",
-        resized.width(), resized.height(), resized.channels()
+        resized.width(),
+        resized.height(),
+        resized.channels()
     );
 
     let hist = gray_buf.compute_histogram(10)?;

--- a/crates/trueno-image/src/buf.rs
+++ b/crates/trueno-image/src/buf.rs
@@ -39,18 +39,9 @@ impl ImageBuf {
     ) -> Result<Self, ImageError> {
         let expected = width * height * channels;
         if data.len() != expected {
-            return Err(ImageError::DimensionMismatch {
-                expected,
-                got: data.len(),
-            });
+            return Err(ImageError::DimensionMismatch { expected, got: data.len() });
         }
-        Ok(Self {
-            data,
-            width,
-            height,
-            channels,
-            dtype: DType::F32,
-        })
+        Ok(Self { data, width, height, channels, dtype: DType::F32 })
     }
 
     /// Create a zero-filled image buffer.
@@ -111,10 +102,7 @@ impl ImageBuf {
     /// Returns error if `channel >= self.channels()`.
     pub fn channel(&self, channel: usize) -> Result<Self, ImageError> {
         if channel >= self.channels {
-            return Err(ImageError::InvalidChannel {
-                channel,
-                max: self.channels,
-            });
+            return Err(ImageError::InvalidChannel { channel, max: self.channels });
         }
         let mut out = Vec::with_capacity(self.width * self.height);
         for i in 0..self.width * self.height {

--- a/crates/trueno-image/src/color.rs
+++ b/crates/trueno-image/src/color.rs
@@ -19,11 +19,7 @@ use crate::error::ImageError;
 /// # Errors
 ///
 /// Returns error if buffer lengths don't match dimensions.
-pub fn rgb_to_gray(
-    rgb: &[f32],
-    width: usize,
-    height: usize,
-) -> Result<Vec<f32>, ImageError> {
+pub fn rgb_to_gray(rgb: &[f32], width: usize, height: usize) -> Result<Vec<f32>, ImageError> {
     let pixels = width * height;
     if rgb.len() != pixels * 3 {
         return Err(ImageError::BufferLengthMismatch {
@@ -53,11 +49,7 @@ pub fn rgb_to_gray(
 /// # Errors
 ///
 /// Returns error if buffer length doesn't match dimensions.
-pub fn rgb_to_hsv(
-    rgb: &[f32],
-    width: usize,
-    height: usize,
-) -> Result<Vec<f32>, ImageError> {
+pub fn rgb_to_hsv(rgb: &[f32], width: usize, height: usize) -> Result<Vec<f32>, ImageError> {
     let pixels = width * height;
     if rgb.len() != pixels * 3 {
         return Err(ImageError::BufferLengthMismatch {
@@ -108,11 +100,7 @@ fn rgb_pixel_to_hsv(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
 /// # Errors
 ///
 /// Returns error if buffer length doesn't match dimensions.
-pub fn hsv_to_rgb(
-    hsv: &[f32],
-    width: usize,
-    height: usize,
-) -> Result<Vec<f32>, ImageError> {
+pub fn hsv_to_rgb(hsv: &[f32], width: usize, height: usize) -> Result<Vec<f32>, ImageError> {
     let pixels = width * height;
     if hsv.len() != pixels * 3 {
         return Err(ImageError::BufferLengthMismatch {

--- a/crates/trueno-image/src/conv.rs
+++ b/crates/trueno-image/src/conv.rs
@@ -210,10 +210,7 @@ pub fn sobel(
 
 /// Gradient magnitude from Sobel output.
 pub fn gradient_magnitude(gx: &[f32], gy: &[f32]) -> Vec<f32> {
-    gx.iter()
-        .zip(gy.iter())
-        .map(|(&x, &y)| (x * x + y * y).sqrt())
-        .collect()
+    gx.iter().zip(gy.iter()).map(|(&x, &y)| (x * x + y * y).sqrt()).collect()
 }
 
 /// Canny edge detection.
@@ -234,10 +231,7 @@ pub fn canny(
     high_threshold: f32,
 ) -> Result<Vec<f32>, ImageError> {
     if low_threshold < 0.0 || high_threshold < low_threshold || high_threshold > 1.0 {
-        return Err(ImageError::InvalidThresholds {
-            low: low_threshold,
-            high: high_threshold,
-        });
+        return Err(ImageError::InvalidThresholds { low: low_threshold, high: high_threshold });
     }
 
     // Step 1: Gaussian blur
@@ -249,11 +243,8 @@ pub fn canny(
 
     // Normalize magnitude to [0, 1]
     let max_mag = mag.iter().copied().fold(0.0f32, f32::max);
-    let mag_norm: Vec<f32> = if max_mag > 0.0 {
-        mag.iter().map(|&m| m / max_mag).collect()
-    } else {
-        mag
-    };
+    let mag_norm: Vec<f32> =
+        if max_mag > 0.0 { mag.iter().map(|&m| m / max_mag).collect() } else { mag };
 
     // Step 3: Non-maximum suppression
     let nms = non_maximum_suppression(&mag_norm, &gx, &gy, width, height);
@@ -277,7 +268,8 @@ fn non_maximum_suppression(
             let angle = gy[idx].atan2(gx[idx]);
             let m = mag[idx];
 
-            let dir = ((angle + std::f32::consts::PI) / std::f32::consts::FRAC_PI_4).round() as usize % 4;
+            let dir =
+                ((angle + std::f32::consts::PI) / std::f32::consts::FRAC_PI_4).round() as usize % 4;
             let (n1, n2) = match dir {
                 0 => (mag[idx - 1], mag[idx + 1]),
                 1 => (mag[(y - 1) * width + x + 1], mag[(y + 1) * width + x - 1]),
@@ -294,13 +286,7 @@ fn non_maximum_suppression(
 }
 
 /// Hysteresis thresholding: connect weak edges to strong edges.
-fn hysteresis_threshold(
-    nms: &[f32],
-    width: usize,
-    height: usize,
-    low: f32,
-    high: f32,
-) -> Vec<f32> {
+fn hysteresis_threshold(nms: &[f32], width: usize, height: usize, low: f32, high: f32) -> Vec<f32> {
     let mut edges = vec![0.0f32; width * height];
     for y in 1..height.saturating_sub(1) {
         for x in 1..width.saturating_sub(1) {
@@ -309,9 +295,14 @@ fn hysteresis_threshold(
                 edges[idx] = 1.0;
             } else if nms[idx] >= low {
                 let has_strong = [
-                    (y - 1, x - 1), (y - 1, x), (y - 1, x + 1),
-                    (y, x - 1),                   (y, x + 1),
-                    (y + 1, x - 1), (y + 1, x), (y + 1, x + 1),
+                    (y - 1, x - 1),
+                    (y - 1, x),
+                    (y - 1, x + 1),
+                    (y, x - 1),
+                    (y, x + 1),
+                    (y + 1, x - 1),
+                    (y + 1, x),
+                    (y + 1, x + 1),
                 ]
                 .iter()
                 .any(|&(ny, nx)| nms[ny * width + nx] >= high);
@@ -424,12 +415,7 @@ pub fn canny_rgb(
 ) -> Result<Vec<f32>, ImageError> {
     let expected = width * height * channels;
     if image.len() != expected {
-        return Err(ImageError::BufferLengthMismatch {
-            expected,
-            got: image.len(),
-            width,
-            height,
-        });
+        return Err(ImageError::BufferLengthMismatch { expected, got: image.len(), width, height });
     }
 
     // Convert to grayscale (BT.601 weights: 0.299R + 0.587G + 0.114B)

--- a/crates/trueno-image/src/histogram.rs
+++ b/crates/trueno-image/src/histogram.rs
@@ -9,7 +9,12 @@ use crate::error::ImageError;
 /// # Errors
 ///
 /// Returns error if dimensions don't match buffer or bins is zero.
-pub fn histogram(image: &[f32], width: usize, height: usize, bins: usize) -> Result<Vec<u32>, ImageError> {
+pub fn histogram(
+    image: &[f32],
+    width: usize,
+    height: usize,
+    bins: usize,
+) -> Result<Vec<u32>, ImageError> {
     if image.len() != width * height {
         return Err(ImageError::BufferLengthMismatch {
             expected: width * height,
@@ -51,7 +56,12 @@ pub fn cumulative_histogram(hist: &[u32]) -> Vec<u32> {
 /// # Errors
 ///
 /// Returns error if dimensions don't match.
-pub fn equalize(image: &[f32], width: usize, height: usize, bins: usize) -> Result<Vec<f32>, ImageError> {
+pub fn equalize(
+    image: &[f32],
+    width: usize,
+    height: usize,
+    bins: usize,
+) -> Result<Vec<f32>, ImageError> {
     let hist = histogram(image, width, height, bins)?;
     let cdf = cumulative_histogram(&hist);
     let total = (width * height) as f32;

--- a/crates/trueno-image/src/lib.rs
+++ b/crates/trueno-image/src/lib.rs
@@ -60,12 +60,7 @@ pub trait ImageOps {
     fn sobel_gradients(&self) -> Result<(ImageBuf, ImageBuf), ImageError>;
 
     /// Apply Canny edge detection (converts multi-channel to grayscale).
-    fn canny_edges(
-        &self,
-        sigma: f32,
-        low: f32,
-        high: f32,
-    ) -> Result<ImageBuf, ImageError>;
+    fn canny_edges(&self, sigma: f32, low: f32, high: f32) -> Result<ImageBuf, ImageError>;
 
     /// Morphological dilation with structuring element.
     fn apply_dilate(&self, se: &[f32], sw: usize, sh: usize) -> Result<ImageBuf, ImageError>;
@@ -151,21 +146,9 @@ impl ImageOps for ImageBuf {
         ))
     }
 
-    fn canny_edges(
-        &self,
-        sigma: f32,
-        low: f32,
-        high: f32,
-    ) -> Result<ImageBuf, ImageError> {
-        let edges = canny_rgb(
-            self.data(),
-            self.width(),
-            self.height(),
-            self.channels(),
-            sigma,
-            low,
-            high,
-        )?;
+    fn canny_edges(&self, sigma: f32, low: f32, high: f32) -> Result<ImageBuf, ImageError> {
+        let edges =
+            canny_rgb(self.data(), self.width(), self.height(), self.channels(), sigma, low, high)?;
         ImageBuf::new(edges, self.width(), self.height(), 1)
     }
 
@@ -219,8 +202,7 @@ impl ImageOps for ImageBuf {
             let mut out = vec![0.0_f32; new_npix * self.channels()];
             for c in 0..self.channels() {
                 let ch = self.channel(c)?;
-                let resized =
-                    resize(ch.data(), self.width(), self.height(), new_w, new_h, interp)?;
+                let resized = resize(ch.data(), self.width(), self.height(), new_w, new_h, interp)?;
                 for i in 0..new_npix {
                     out[i * self.channels() + c] = resized[i];
                 }

--- a/crates/trueno-image/src/morphology.rs
+++ b/crates/trueno-image/src/morphology.rs
@@ -80,7 +80,11 @@ fn neighborhood_max(
             }
         }
     }
-    if max_val == f32::NEG_INFINITY { 0.0 } else { max_val }
+    if max_val == f32::NEG_INFINITY {
+        0.0
+    } else {
+        max_val
+    }
 }
 
 /// Compute min over SE neighborhood at pixel (px, py).
@@ -113,7 +117,11 @@ fn neighborhood_min(
             }
         }
     }
-    if min_val == f32::INFINITY { 0.0 } else { min_val }
+    if min_val == f32::INFINITY {
+        0.0
+    } else {
+        min_val
+    }
 }
 
 /// Morphological opening: erode then dilate.

--- a/crates/trueno-image/src/resize.rs
+++ b/crates/trueno-image/src/resize.rs
@@ -37,10 +37,7 @@ pub fn resize(
         });
     }
     if dst_w == 0 || dst_h == 0 {
-        return Err(ImageError::ZeroDimension {
-            width: dst_w,
-            height: dst_h,
-        });
+        return Err(ImageError::ZeroDimension { width: dst_w, height: dst_h });
     }
 
     let mut output = vec![0.0f32; dst_w * dst_h];
@@ -61,15 +58,9 @@ pub fn resize(
                     let iy = iy.min(src_h - 1);
                     image[iy * src_w + ix]
                 }
-                Interpolation::Bilinear => {
-                    bilinear_sample(image, src_w, src_h, sx, sy)
-                }
-                Interpolation::Bicubic => {
-                    bicubic_sample(image, src_w, src_h, sx, sy)
-                }
-                Interpolation::Lanczos => {
-                    lanczos_sample(image, src_w, src_h, sx, sy)
-                }
+                Interpolation::Bilinear => bilinear_sample(image, src_w, src_h, sx, sy),
+                Interpolation::Bicubic => bicubic_sample(image, src_w, src_h, sx, sy),
+                Interpolation::Lanczos => lanczos_sample(image, src_w, src_h, sx, sy),
             };
         }
     }

--- a/crates/trueno-image/src/tests.rs
+++ b/crates/trueno-image/src/tests.rs
@@ -16,11 +16,7 @@ fn test_identity_kernel() {
     let out = conv2d(&image, 3, 3, &delta, 3, 3, BorderMode::Zero).expect("ok");
 
     // Interior pixel should be exactly preserved
-    assert!(
-        (out[4] - 5.0).abs() < 1e-6,
-        "Identity kernel failed at center: {}",
-        out[4]
-    );
+    assert!((out[4] - 5.0).abs() < 1e-6, "Identity kernel failed at center: {}", out[4]);
 }
 
 #[test]
@@ -94,10 +90,7 @@ fn test_gaussian_blur_constant_image() {
 
     // Blurring a constant image should give the same constant
     for (i, &v) in blurred.iter().enumerate() {
-        assert!(
-            (v - 5.0).abs() < 1e-3,
-            "Gaussian blur changed constant at {i}: {v}"
-        );
+        assert!((v - 5.0).abs() < 1e-3, "Gaussian blur changed constant at {i}: {v}");
     }
 }
 
@@ -112,10 +105,7 @@ fn test_gaussian_blur_reduces_range() {
     let max_blurred = blurred.iter().copied().fold(0.0f32, f32::max);
 
     // Blurring should reduce the peak
-    assert!(
-        max_blurred < 100.0,
-        "Gaussian blur didn't reduce peak: {max_blurred}"
-    );
+    assert!(max_blurred < 100.0, "Gaussian blur didn't reduce peak: {max_blurred}");
     // Total energy should be approximately conserved
     let sum_orig: f32 = image.iter().sum();
     let sum_blurred: f32 = blurred.iter().sum();
@@ -169,11 +159,7 @@ fn test_sobel_horizontal_edge() {
     let edge_y = h / 2;
     let center_x = w / 2;
     let idx = edge_y * w + center_x;
-    assert!(
-        gy[idx].abs() > 0.1,
-        "Expected vertical gradient at edge: gy={}",
-        gy[idx]
-    );
+    assert!(gy[idx].abs() > 0.1, "Expected vertical gradient at edge: gy={}", gy[idx]);
 }
 
 // ============================================================================
@@ -244,7 +230,7 @@ fn test_conv2d_buffer_mismatch() {
 fn test_border_clamp() {
     let image = vec![1.0, 2.0, 3.0, 4.0_f32]; // 2×2
     let k = [0.0, 1.0, 0.0_f32]; // 3×1 horizontal kernel (just right neighbor)
-    // Actually let's use a 3x1 → need it as 1x3 for conv2d (kw=3, kh=1)
+                                 // Actually let's use a 3x1 → need it as 1x3 for conv2d (kw=3, kh=1)
     let out = conv2d(&image, 2, 2, &k, 3, 1, BorderMode::Clamp).expect("ok");
 
     // At (0,0): neighbors are clamp(-1,0)=image[0]=1, image[0]=1, image[1]=2
@@ -502,7 +488,12 @@ fn test_hsv_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
 
     for i in 0..colors.len() {
         let err = (colors[i] - recovered[i]).abs();
-        assert!(err < 1e-4, "HSV roundtrip at {i}: orig={}, rec={}, err={err}", colors[i], recovered[i]);
+        assert!(
+            err < 1e-4,
+            "HSV roundtrip at {i}: orig={}, rec={}, err={err}",
+            colors[i],
+            recovered[i]
+        );
     }
     Ok(())
 }
@@ -687,8 +678,7 @@ fn test_conv_wrap_periodic() -> Result<(), Box<dyn std::error::Error>> {
     for (i, &v) in out.iter().enumerate() {
         assert!((v - 3.0).abs() < 1e-5, "Wrap identity at {i}: {v}");
     }
-    Ok(()
-)
+    Ok(())
 }
 
 // ── ImageBuf tests ──────────────────────────────────────────────
@@ -990,10 +980,7 @@ fn test_falsify_canny_binary_output() {
     }
     let edges = canny(&image, w, h, 1.0, 0.05, 0.15).expect("ok");
     for (i, &v) in edges.iter().enumerate() {
-        assert!(
-            v.abs() < 1e-5 || (v - 1.0).abs() < 1e-5,
-            "Canny output not binary at {i}: {v}"
-        );
+        assert!(v.abs() < 1e-5 || (v - 1.0).abs() < 1e-5, "Canny output not binary at {i}: {v}");
     }
 }
 
@@ -1017,7 +1004,12 @@ fn test_falsify_resize_same_size() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_falsify_resize_1x1() -> Result<(), Box<dyn std::error::Error>> {
     let image = vec![0.42_f32];
-    for interp in [Interpolation::Nearest, Interpolation::Bilinear, Interpolation::Bicubic, Interpolation::Lanczos] {
+    for interp in [
+        Interpolation::Nearest,
+        Interpolation::Bilinear,
+        Interpolation::Bicubic,
+        Interpolation::Lanczos,
+    ] {
         let result = resize(&image, 1, 1, 1, 1, interp)?;
         assert!((result[0] - 0.42).abs() < 0.01, "1×1 resize ({interp:?}): {}", result[0]);
     }

--- a/crates/trueno-quant/src/tests.rs
+++ b/crates/trueno-quant/src/tests.rs
@@ -145,7 +145,8 @@ fn test_q6k_dequantize_nan_scale() {
         assert!(
             v.abs() < f32::EPSILON,
             "Q6K with NaN scale should produce 0.0 at index {}, got {}",
-            i, v
+            i,
+            v
         );
     }
 }
@@ -188,7 +189,11 @@ fn test_q6k_simd_scaling_roundtrip() {
         .map(|i| {
             let base = (i as f32 - 128.0) / 10.0;
             // Introduce sharp scaling change at lane boundary
-            if i % 16 < 8 { base * 0.01 } else { base * 100.0 }
+            if i % 16 < 8 {
+                base * 0.01
+            } else {
+                base * 100.0
+            }
         })
         .collect();
 
@@ -201,16 +206,14 @@ fn test_q6k_simd_scaling_roundtrip() {
     }
 
     // Roundtrip error should be bounded
-    let max_err = data
-        .iter()
-        .zip(dequantized.iter())
-        .map(|(a, b)| (a - b).abs())
-        .fold(0.0f32, f32::max);
+    let max_err =
+        data.iter().zip(dequantized.iter()).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
     let range = data.iter().fold(f32::NEG_INFINITY, |a, &b| a.max(b))
         - data.iter().fold(f32::INFINITY, |a, &b| a.min(b));
     assert!(
         max_err < range * 0.15,
         "Q6K SIMD scaling roundtrip error {} exceeds 15% of range {}",
-        max_err, range
+        max_err,
+        range
     );
 }

--- a/crates/trueno-rand/examples/rng_demo.rs
+++ b/crates/trueno-rand/examples/rng_demo.rs
@@ -54,7 +54,8 @@ fn main() {
     let mut tf4 = Threefry4x64::new(101);
     let mut tf_normal = vec![0.0f32; 10000];
     tf4.fill_normal(&mut tf_normal);
-    let tf_n_mean: f64 = tf_normal.iter().map(|&v| f64::from(v)).sum::<f64>() / tf_normal.len() as f64;
+    let tf_n_mean: f64 =
+        tf_normal.iter().map(|&v| f64::from(v)).sum::<f64>() / tf_normal.len() as f64;
     println!("Normal mean: {tf_n_mean:.4} (expected: 0.0)");
 
     let tf_key = [42u64, 0, 0, 0];

--- a/crates/trueno-rand/src/philox.rs
+++ b/crates/trueno-rand/src/philox.rs
@@ -32,10 +32,7 @@ const PHILOX_W1: u32 = 0xBB67_AE85; // sqrt(3)-1
 impl Philox4x32 {
     /// Create a new Philox RNG with the given seed.
     pub fn new(seed: u64) -> Self {
-        Self {
-            key: [seed as u32, (seed >> 32) as u32],
-            counter: [0, 0, 0, 0],
-        }
+        Self { key: [seed as u32, (seed >> 32) as u32], counter: [0, 0, 0, 0] }
     }
 
     /// Create with explicit key and counter (for reproducible parallel generation).
@@ -121,12 +118,7 @@ fn philox4x32_round(ctr: [u32; 4], key: [u32; 2]) -> [u32; 4] {
     let lo1 = (u64::from(PHILOX_M1) * u64::from(ctr[2])) as u32;
     let hi1 = ((u64::from(PHILOX_M1) * u64::from(ctr[2])) >> 32) as u32;
 
-    [
-        hi1 ^ ctr[1] ^ key[0],
-        lo1,
-        hi0 ^ ctr[3] ^ key[1],
-        lo0,
-    ]
+    [hi1 ^ ctr[1] ^ key[0], lo1, hi0 ^ ctr[3] ^ key[1], lo0]
 }
 
 /// Full Philox 4x32-10: 10 rounds with key schedule.

--- a/crates/trueno-rand/src/tests.rs
+++ b/crates/trueno-rand/src/tests.rs
@@ -38,10 +38,7 @@ fn test_different_counters_differ() {
     let key = [42u32, 0];
     let c1 = [0, 0, 0, 0];
     let c2 = [1, 0, 0, 0];
-    assert_ne!(
-        Philox4x32::generate_at(key, c1),
-        Philox4x32::generate_at(key, c2)
-    );
+    assert_ne!(Philox4x32::generate_at(key, c1), Philox4x32::generate_at(key, c2));
 }
 
 // ============================================================================
@@ -66,10 +63,7 @@ fn test_uniform_mean() {
     rng.fill_uniform(&mut buf);
 
     let mean: f32 = buf.iter().sum::<f32>() / buf.len() as f32;
-    assert!(
-        (mean - 0.5).abs() < 0.01,
-        "Uniform mean {mean} too far from 0.5"
-    );
+    assert!((mean - 0.5).abs() < 0.01, "Uniform mean {mean} too far from 0.5");
 }
 
 #[test]
@@ -89,10 +83,7 @@ fn test_uniform_variance() {
         / buf.len() as f64;
 
     // Uniform[0,1) variance = 1/12 ≈ 0.0833
-    assert!(
-        (var - 1.0 / 12.0).abs() < 0.005,
-        "Uniform variance {var} too far from 1/12"
-    );
+    assert!((var - 1.0 / 12.0).abs() < 0.005, "Uniform variance {var} too far from 1/12");
 }
 
 // ============================================================================
@@ -115,14 +106,8 @@ fn test_normal_mean_and_variance() {
         .sum::<f64>()
         / buf.len() as f64;
 
-    assert!(
-        mean.abs() < 0.02,
-        "Normal mean {mean} too far from 0"
-    );
-    assert!(
-        (var - 1.0).abs() < 0.05,
-        "Normal variance {var} too far from 1.0"
-    );
+    assert!(mean.abs() < 0.02, "Normal mean {mean} too far from 0");
+    assert!((var - 1.0).abs() < 0.05, "Normal variance {var} too far from 1.0");
 }
 
 #[test]
@@ -176,10 +161,7 @@ fn test_chi_squared_uniformity() {
         .sum();
 
     // Chi-squared critical value for 99 df, p=0.001 ≈ 148.2
-    assert!(
-        chi_sq < 150.0,
-        "Chi-squared {chi_sq} exceeds threshold (poor uniformity)"
-    );
+    assert!(chi_sq < 150.0, "Chi-squared {chi_sq} exceeds threshold (poor uniformity)");
 }
 
 // ============================================================================
@@ -221,10 +203,7 @@ fn test_threefry_different_counters_differ() {
     let key = [42u64, 0, 0, 0];
     let c1 = [0, 0, 0, 0];
     let c2 = [1, 0, 0, 0];
-    assert_ne!(
-        Threefry4x64::generate_at(key, c1),
-        Threefry4x64::generate_at(key, c2)
-    );
+    assert_ne!(Threefry4x64::generate_at(key, c1), Threefry4x64::generate_at(key, c2));
 }
 
 #[test]
@@ -245,10 +224,7 @@ fn test_threefry_uniform_mean() {
     rng.fill_uniform(&mut buf);
 
     let mean: f32 = buf.iter().sum::<f32>() / buf.len() as f32;
-    assert!(
-        (mean - 0.5).abs() < 0.01,
-        "Threefry uniform mean {mean} too far from 0.5"
-    );
+    assert!((mean - 0.5).abs() < 0.01, "Threefry uniform mean {mean} too far from 0.5");
 }
 
 #[test]
@@ -267,14 +243,8 @@ fn test_threefry_normal_mean_and_variance() {
         .sum::<f64>()
         / buf.len() as f64;
 
-    assert!(
-        mean.abs() < 0.02,
-        "Threefry normal mean {mean} too far from 0"
-    );
-    assert!(
-        (var - 1.0).abs() < 0.05,
-        "Threefry normal variance {var} too far from 1.0"
-    );
+    assert!(mean.abs() < 0.02, "Threefry normal mean {mean} too far from 0");
+    assert!((var - 1.0).abs() < 0.05, "Threefry normal variance {var} too far from 1.0");
 }
 
 #[test]
@@ -478,10 +448,7 @@ fn test_falsify_kolmogorov_smirnov_uniform() {
         }
     }
     // KS critical value at α=0.01 for n=10000 ≈ 1.63/sqrt(n) ≈ 0.0163
-    assert!(
-        max_d < 0.02,
-        "KS statistic {max_d} exceeds threshold (distribution not uniform)"
-    );
+    assert!(max_d < 0.02, "KS statistic {max_d} exceeds threshold (distribution not uniform)");
 }
 
 #[test]

--- a/crates/trueno-rand/src/threefry.rs
+++ b/crates/trueno-rand/src/threefry.rs
@@ -24,16 +24,8 @@ pub struct Threefry4x64 {
 }
 
 // Rotation constants for Threefry 4x64 (from the original paper, Table 4)
-const R_4X64: [[u32; 2]; 8] = [
-    [14, 16],
-    [52, 57],
-    [23, 40],
-    [5, 37],
-    [25, 33],
-    [46, 12],
-    [58, 22],
-    [32, 32],
-];
+const R_4X64: [[u32; 2]; 8] =
+    [[14, 16], [52, 57], [23, 40], [5, 37], [25, 33], [46, 12], [58, 22], [32, 32]];
 
 // Skein key schedule constant (2^64 / golden ratio)
 const KS_PARITY: u64 = 0x1BD1_1BDA_A9FC_1A22;
@@ -41,10 +33,7 @@ const KS_PARITY: u64 = 0x1BD1_1BDA_A9FC_1A22;
 impl Threefry4x64 {
     /// Create a new Threefry RNG with the given seed.
     pub fn new(seed: u64) -> Self {
-        Self {
-            key: [seed, seed.wrapping_mul(0x9E37_79B9_7F4A_7C15), 0, 0],
-            counter: [0, 0, 0, 0],
-        }
+        Self { key: [seed, seed.wrapping_mul(0x9E37_79B9_7F4A_7C15), 0, 0], counter: [0, 0, 0, 0] }
     }
 
     /// Create with explicit key and counter (for reproducible parallel generation).

--- a/crates/trueno-solve/benches/solve_bench.rs
+++ b/crates/trueno-solve/benches/solve_bench.rs
@@ -16,9 +16,7 @@ fn make_spd_matrix(n: usize) -> Vec<f32> {
 }
 
 fn make_general_matrix(m: usize, n: usize) -> Vec<f32> {
-    (0..m * n)
-        .map(|i| ((i * 7 + 3) % 97) as f32 / 97.0)
-        .collect()
+    (0..m * n).map(|i| ((i * 7 + 3) % 97) as f32 / 97.0).collect()
 }
 
 fn bench_lu(c: &mut Criterion) {

--- a/crates/trueno-solve/examples/solver_demo.rs
+++ b/crates/trueno-solve/examples/solver_demo.rs
@@ -6,7 +6,7 @@
 
 use trueno_solve::{
     cholesky, f32_to_f16, gemm_ex, gemm_ex_epilogue, gemm_strided_batched, lu_factorize,
-    qr_factorize, svd, syr2k, syrk, symm, trmm, trsm, Epilogue, Solver,
+    qr_factorize, svd, symm, syr2k, syrk, trmm, trsm, Epilogue, Solver,
 };
 use trueno_solve::{DiagonalType, TriangularSide};
 
@@ -50,15 +50,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a_syrk = [1.0, 2.0, 3.0, 4.0_f32]; // 2×2
     let mut c_syrk = [0.0_f32; 4];
     syrk(&a_syrk, &mut c_syrk, 2, 2, 1.0, 0.0)?;
-    println!("syrk(A·Aᵀ): [{:.1}, {:.1}; {:.1}, {:.1}]",
-        c_syrk[0], c_syrk[1], c_syrk[2], c_syrk[3]);
+    println!(
+        "syrk(A·Aᵀ): [{:.1}, {:.1}; {:.1}, {:.1}]",
+        c_syrk[0], c_syrk[1], c_syrk[2], c_syrk[3]
+    );
 
     // syr2k: C = A·Bᵀ + B·Aᵀ
     let b_syr2k = [5.0, 6.0, 7.0, 8.0_f32];
     let mut c_syr2k = [0.0_f32; 4];
     syr2k(&a_syrk, &b_syr2k, &mut c_syr2k, 2, 2, 1.0, 0.0)?;
-    println!("syr2k: [{:.1}, {:.1}; {:.1}, {:.1}]",
-        c_syr2k[0], c_syr2k[1], c_syr2k[2], c_syr2k[3]);
+    println!("syr2k: [{:.1}, {:.1}; {:.1}, {:.1}]", c_syr2k[0], c_syr2k[1], c_syr2k[2], c_syr2k[3]);
 
     // trmm: B = A·B (lower triangular)
     let a_tri = [2.0, 0.0, 3.0, 4.0_f32];
@@ -71,34 +72,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let b_sym = [1.0, 0.0, 0.0, 1.0_f32];
     let mut c_sym = [0.0_f32; 4];
     symm(&a_sym, &b_sym, &mut c_sym, 2, 2, 1.0, 0.0)?;
-    println!("symm: [{:.1}, {:.1}; {:.1}, {:.1}]",
-        c_sym[0], c_sym[1], c_sym[2], c_sym[3]);
+    println!("symm: [{:.1}, {:.1}; {:.1}, {:.1}]", c_sym[0], c_sym[1], c_sym[2], c_sym[3]);
 
     // ── gemmEx (mixed-precision f16→f32) ───────────────────
     println!("\n--- gemmEx (mixed-precision) ---");
-    let a_f16: Vec<u16> = [1.0, 2.0, 3.0, 4.0_f32]
-        .iter()
-        .map(|&v| f32_to_f16(v))
-        .collect();
-    let b_f16: Vec<u16> = [5.0, 6.0, 7.0, 8.0_f32]
-        .iter()
-        .map(|&v| f32_to_f16(v))
-        .collect();
+    let a_f16: Vec<u16> = [1.0, 2.0, 3.0, 4.0_f32].iter().map(|&v| f32_to_f16(v)).collect();
+    let b_f16: Vec<u16> = [5.0, 6.0, 7.0, 8.0_f32].iter().map(|&v| f32_to_f16(v)).collect();
     let mut c_ex = [0.0_f32; 4];
     gemm_ex(&a_f16, &b_f16, &mut c_ex, 2, 2, 2, 1.0, 0.0)?;
-    println!(
-        "f16 matmul: [{:.1}, {:.1}; {:.1}, {:.1}]",
-        c_ex[0], c_ex[1], c_ex[2], c_ex[3]
-    );
+    println!("f16 matmul: [{:.1}, {:.1}; {:.1}, {:.1}]", c_ex[0], c_ex[1], c_ex[2], c_ex[3]);
 
     // ── gemmStridedBatched ───────────────────────────────
     println!("\n--- gemmStridedBatched ---");
     let a_batch = [1.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0, 2.0_f32]; // 2 batches of 2×2
     let b_batch = [3.0, 4.0, 5.0, 6.0, 1.0, 1.0, 1.0, 1.0_f32];
     let mut c_batch = [0.0_f32; 8];
-    gemm_strided_batched(
-        &a_batch, 4, &b_batch, 4, &mut c_batch, 4, 2, 2, 2, 2, 1.0, 0.0,
-    )?;
+    gemm_strided_batched(&a_batch, 4, &b_batch, 4, &mut c_batch, 4, 2, 2, 2, 2, 1.0, 0.0)?;
     println!(
         "Batch 0: [{:.1}, {:.1}; {:.1}, {:.1}]",
         c_batch[0], c_batch[1], c_batch[2], c_batch[3]
@@ -113,12 +102,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let lu2 = lu_factorize(&[4.0, 1.0, 1.0, 3.0_f32], 2)?;
     let solver: &dyn Solver = &lu2;
     let x_dyn = solver.solve(&[5.0, 7.0])?;
-    println!(
-        "dyn Solver (LU): dim={}, x=[{:.4}, {:.4}]",
-        solver.dimension(),
-        x_dyn[0],
-        x_dyn[1]
-    );
+    println!("dyn Solver (LU): dim={}, x=[{:.4}, {:.4}]", solver.dimension(), x_dyn[0], x_dyn[1]);
 
     let chol2 = cholesky(&[4.0, 2.0, 2.0, 3.0_f32], 2)?;
     let solver2: &dyn Solver = &chol2;
@@ -132,18 +116,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── gemmEx with epilogue fusion ─────────────────────────
     println!("\n--- gemmEx with epilogue fusion ---");
-    let a_ep: Vec<u16> = [1.0, 0.0, 0.0, 1.0_f32]
-        .iter()
-        .map(|&v| f32_to_f16(v))
-        .collect();
-    let b_ep: Vec<u16> = [-3.0, 4.0, 5.0, -6.0_f32]
-        .iter()
-        .map(|&v| f32_to_f16(v))
-        .collect();
+    let a_ep: Vec<u16> = [1.0, 0.0, 0.0, 1.0_f32].iter().map(|&v| f32_to_f16(v)).collect();
+    let b_ep: Vec<u16> = [-3.0, 4.0, 5.0, -6.0_f32].iter().map(|&v| f32_to_f16(v)).collect();
     let mut c_relu = [0.0_f32; 4];
-    gemm_ex_epilogue(
-        &a_ep, &b_ep, &mut c_relu, 2, 2, 2, 1.0, 0.0, Epilogue::Relu, None,
-    )?;
+    gemm_ex_epilogue(&a_ep, &b_ep, &mut c_relu, 2, 2, 2, 1.0, 0.0, Epilogue::Relu, None)?;
     println!(
         "ReLU epilogue: [{:.1}, {:.1}; {:.1}, {:.1}]",
         c_relu[0], c_relu[1], c_relu[2], c_relu[3]
@@ -151,9 +127,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut c_bias = [0.0_f32; 4];
     let bias = [100.0, 200.0_f32];
-    gemm_ex_epilogue(
-        &a_ep, &b_ep, &mut c_bias, 2, 2, 2, 1.0, 0.0, Epilogue::Bias, Some(&bias),
-    )?;
+    gemm_ex_epilogue(&a_ep, &b_ep, &mut c_bias, 2, 2, 2, 1.0, 0.0, Epilogue::Bias, Some(&bias))?;
     println!(
         "Bias epilogue: [{:.1}, {:.1}; {:.1}, {:.1}]",
         c_bias[0], c_bias[1], c_bias[2], c_bias[3]

--- a/crates/trueno-solve/src/blas3.rs
+++ b/crates/trueno-solve/src/blas3.rs
@@ -326,7 +326,11 @@ fn f16_to_f32(h: u16) -> f32 {
     if exp == 31 {
         // Inf or NaN
         return if mant == 0 {
-            if sign == 1 { f32::NEG_INFINITY } else { f32::INFINITY }
+            if sign == 1 {
+                f32::NEG_INFINITY
+            } else {
+                f32::INFINITY
+            }
         } else {
             f32::NAN
         };
@@ -334,9 +338,7 @@ fn f16_to_f32(h: u16) -> f32 {
 
     // Normal: value = (-1)^sign * 2^(exp-15) * (1 + mant/1024)
     let f32_exp = (exp as i32) - 15 + 127;
-    let f32_bits = ((sign as u32) << 31)
-        | ((f32_exp as u32) << 23)
-        | ((mant as u32) << 13);
+    let f32_bits = ((sign as u32) << 31) | ((f32_exp as u32) << 23) | ((mant as u32) << 13);
     f32::from_bits(f32_bits)
 }
 
@@ -455,9 +457,7 @@ fn validate_bias_if_needed<'a>(
     if !needs_bias {
         return Ok(None);
     }
-    let bv = bias.ok_or(SolverError::InvalidInput {
-        reason: "epilogue requires bias vector",
-    })?;
+    let bv = bias.ok_or(SolverError::InvalidInput { reason: "epilogue requires bias vector" })?;
     if bv.len() != n {
         return Err(SolverError::BufferLengthMismatch {
             expected: n,
@@ -502,14 +502,14 @@ fn gelu(x: f32) -> f32 {
 }
 
 /// Validate buffer length matches expected dimensions.
-fn validate_buffer(buf: &[f32], expected: usize, rows: usize, cols: usize) -> Result<(), SolverError> {
+fn validate_buffer(
+    buf: &[f32],
+    expected: usize,
+    rows: usize,
+    cols: usize,
+) -> Result<(), SolverError> {
     if buf.len() != expected {
-        return Err(SolverError::BufferLengthMismatch {
-            expected,
-            got: buf.len(),
-            rows,
-            cols,
-        });
+        return Err(SolverError::BufferLengthMismatch { expected, got: buf.len(), rows, cols });
     }
     Ok(())
 }

--- a/crates/trueno-solve/src/cholesky.rs
+++ b/crates/trueno-solve/src/cholesky.rs
@@ -27,10 +27,7 @@ pub struct CholeskyFactorization {
 /// Returns `NotPositiveDefinite` if a non-positive pivot is encountered.
 pub fn cholesky(a: &[f32], n: usize) -> Result<CholeskyFactorization, SolverError> {
     if a.len() != n * n {
-        return Err(SolverError::NotSquare {
-            rows: n,
-            cols: a.len() / n.max(1),
-        });
+        return Err(SolverError::NotSquare { rows: n, cols: a.len() / n.max(1) });
     }
 
     let mut l = vec![0.0f32; n * n];
@@ -71,10 +68,7 @@ impl CholeskyFactorization {
     /// Returns error on dimension mismatch.
     pub fn solve(&self, b: &[f32]) -> Result<Vec<f32>, SolverError> {
         if b.len() != self.n {
-            return Err(SolverError::DimensionMismatch {
-                matrix_n: self.n,
-                rhs_len: b.len(),
-            });
+            return Err(SolverError::DimensionMismatch { matrix_n: self.n, rhs_len: b.len() });
         }
 
         let n = self.n;

--- a/crates/trueno-solve/src/lib.rs
+++ b/crates/trueno-solve/src/lib.rs
@@ -33,8 +33,7 @@ mod trsm;
 mod tests;
 
 pub use blas3::{
-    f32_to_f16, gemm_ex, gemm_ex_epilogue, gemm_strided_batched, symm, syr2k, syrk, trmm,
-    Epilogue,
+    f32_to_f16, gemm_ex, gemm_ex_epilogue, gemm_strided_batched, symm, syr2k, syrk, trmm, Epilogue,
 };
 pub use cholesky::{cholesky, CholeskyFactorization};
 pub use error::SolverError;

--- a/crates/trueno-solve/src/lu.rs
+++ b/crates/trueno-solve/src/lu.rs
@@ -39,10 +39,7 @@ pub struct LuFactorization {
 #[allow(clippy::cast_precision_loss)]
 pub fn lu_factorize(a: &[f32], n: usize) -> Result<LuFactorization, SolverError> {
     if a.len() != n * n {
-        return Err(SolverError::NotSquare {
-            rows: n,
-            cols: a.len() / n.max(1),
-        });
+        return Err(SolverError::NotSquare { rows: n, cols: a.len() / n.max(1) });
     }
 
     let mut lu = a.to_vec();
@@ -97,10 +94,7 @@ impl LuFactorization {
     /// Returns error on dimension mismatch.
     pub fn solve(&self, b: &[f32]) -> Result<Vec<f32>, SolverError> {
         if b.len() != self.n {
-            return Err(SolverError::DimensionMismatch {
-                matrix_n: self.n,
-                rhs_len: b.len(),
-            });
+            return Err(SolverError::DimensionMismatch { matrix_n: self.n, rhs_len: b.len() });
         }
 
         let n = self.n;

--- a/crates/trueno-solve/src/qr.rs
+++ b/crates/trueno-solve/src/qr.rs
@@ -150,10 +150,7 @@ impl QrFactorization {
     /// Returns error on dimension mismatch.
     pub fn solve(&self, b: &[f32]) -> Result<Vec<f32>, SolverError> {
         if b.len() != self.m {
-            return Err(SolverError::DimensionMismatch {
-                matrix_n: self.m,
-                rhs_len: b.len(),
-            });
+            return Err(SolverError::DimensionMismatch { matrix_n: self.m, rhs_len: b.len() });
         }
 
         let m = self.m;

--- a/crates/trueno-solve/src/svd.rs
+++ b/crates/trueno-solve/src/svd.rs
@@ -85,7 +85,13 @@ fn jacobi_sweeps(work: &mut [f32], v: &mut [f32], m: usize, n: usize, tol: f32) 
 /// Apply a single Jacobi rotation to column pair (p, q).
 /// Returns true if a rotation was applied (columns were not orthogonal).
 fn apply_jacobi_rotation(
-    work: &mut [f32], v: &mut [f32], m: usize, n: usize, p: usize, q: usize, tol: f32,
+    work: &mut [f32],
+    v: &mut [f32],
+    m: usize,
+    n: usize,
+    p: usize,
+    q: usize,
+    tol: f32,
 ) -> bool {
     let (app, apq, aqq) = gram_elements(work, m, n, p, q);
 
@@ -172,7 +178,12 @@ fn compute_u_matrix(work: &[f32], sigma: &[f32], m: usize, n: usize, min_mn: usi
 /// Sort singular values descending and assemble the final SvdResult.
 #[allow(clippy::cast_precision_loss)]
 fn assemble_sorted_result(
-    u: Vec<f32>, v: Vec<f32>, sigma: Vec<f32>, m: usize, n: usize, min_mn: usize,
+    u: Vec<f32>,
+    v: Vec<f32>,
+    sigma: Vec<f32>,
+    m: usize,
+    n: usize,
+    min_mn: usize,
 ) -> Result<SvdResult, SolverError> {
     let mut indices: Vec<usize> = (0..min_mn).collect();
     indices.sort_by(|&a, &b| sigma[b].partial_cmp(&sigma[a]).unwrap_or(std::cmp::Ordering::Equal));
@@ -206,11 +217,5 @@ fn assemble_sorted_result(
         }
     }
 
-    Ok(SvdResult {
-        u: u_sorted,
-        sigma: sigma_sorted,
-        vt,
-        m,
-        n,
-    })
+    Ok(SvdResult { u: u_sorted, sigma: sigma_sorted, vt, m, n })
 }

--- a/crates/trueno-solve/src/tests.rs
+++ b/crates/trueno-solve/src/tests.rs
@@ -286,12 +286,7 @@ fn test_cholesky_2x2() {
     }
 
     for i in 0..4 {
-        assert!(
-            (recon[i] - a[i]).abs() < 1e-5,
-            "LL^T[{i}]={}, A[{i}]={}",
-            recon[i],
-            a[i]
-        );
+        assert!((recon[i] - a[i]).abs() < 1e-5, "LL^T[{i}]={}, A[{i}]={}", recon[i], a[i]);
     }
 }
 
@@ -333,12 +328,7 @@ fn test_cholesky_3x3() {
     }
 
     for i in 0..9 {
-        assert!(
-            (recon[i] - a[i]).abs() < 1e-3,
-            "LL^T[{i}]={}, A[{i}]={}",
-            recon[i],
-            a[i]
-        );
+        assert!((recon[i] - a[i]).abs() < 1e-3, "LL^T[{i}]={}, A[{i}]={}", recon[i], a[i]);
     }
 }
 
@@ -592,7 +582,7 @@ fn test_symm_alpha_beta() -> Result<(), Box<dyn std::error::Error>> {
     let a = [1.0, 0.0, 0.0, 1.0_f32]; // I
     let b = [2.0, 3.0_f32]; // 2×1
     let mut c = [10.0, 20.0_f32]; // 2×1
-    // C = 2·I·B + 0.5·C = [4+5, 6+10] = [9, 16]
+                                  // C = 2·I·B + 0.5·C = [4+5, 6+10] = [9, 16]
     symm(&a, &b, &mut c, 2, 1, 2.0, 0.5)?;
     assert!((c[0] - 9.0).abs() < 1e-5);
     assert!((c[1] - 16.0).abs() < 1e-5);
@@ -692,7 +682,8 @@ fn test_gemm_ex_alpha_beta() -> Result<(), Box<dyn std::error::Error>> {
 fn test_gemm_ex_matmul_2x3_3x2() -> Result<(), Box<dyn std::error::Error>> {
     // A = [[1,2,3],[4,5,6]], B = [[7,8],[9,10],[11,12]]
     let a: Vec<u16> = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0_f32].iter().map(|&v| f32_to_f16(v)).collect();
-    let b: Vec<u16> = [7.0, 8.0, 9.0, 10.0, 11.0, 12.0_f32].iter().map(|&v| f32_to_f16(v)).collect();
+    let b: Vec<u16> =
+        [7.0, 8.0, 9.0, 10.0, 11.0, 12.0_f32].iter().map(|&v| f32_to_f16(v)).collect();
     let mut c = [0.0_f32; 4];
     gemm_ex(&a, &b, &mut c, 2, 2, 3, 1.0, 0.0)?;
     // C = [[58, 64], [139, 154]]
@@ -711,8 +702,7 @@ fn test_f16_roundtrip() {
         let h = f32_to_f16(v);
         // Use gemm_ex with 1×1 identity to convert back (α=1, β=0)
         let mut c = [0.0_f32];
-        gemm_ex(&[h], &[f32_to_f16(1.0)], &mut c, 1, 1, 1, 1.0, 0.0)
-            .expect("gemm_ex roundtrip ok");
+        gemm_ex(&[h], &[f32_to_f16(1.0)], &mut c, 1, 1, 1, 1.0, 0.0).expect("gemm_ex roundtrip ok");
         assert!((c[0] - v).abs() < 0.01, "f16 roundtrip failed for {v}: got {}", c[0]);
     }
 }

--- a/crates/trueno-solve/src/trsm.rs
+++ b/crates/trueno-solve/src/trsm.rs
@@ -48,16 +48,10 @@ pub fn trsm(
     diag: DiagonalType,
 ) -> Result<TrsmResult, SolverError> {
     if a.len() != n * n {
-        return Err(SolverError::DimensionMismatch {
-            matrix_n: n,
-            rhs_len: a.len(),
-        });
+        return Err(SolverError::DimensionMismatch { matrix_n: n, rhs_len: a.len() });
     }
     if b.len() != n * nrhs {
-        return Err(SolverError::DimensionMismatch {
-            matrix_n: n,
-            rhs_len: b.len(),
-        });
+        return Err(SolverError::DimensionMismatch { matrix_n: n, rhs_len: b.len() });
     }
 
     let mut x = b.to_vec();
@@ -71,7 +65,13 @@ pub fn trsm(
 }
 
 /// Apply diagonal scaling (unit or non-unit) to a substitution result.
-fn apply_diagonal(a: &[f32], n: usize, i: usize, sum: f32, diag: DiagonalType) -> Result<f32, SolverError> {
+fn apply_diagonal(
+    a: &[f32],
+    n: usize,
+    i: usize,
+    sum: f32,
+    diag: DiagonalType,
+) -> Result<f32, SolverError> {
     match diag {
         DiagonalType::Unit => Ok(sum),
         DiagonalType::NonUnit => {

--- a/crates/trueno-sparse/benches/sparse_bench.rs
+++ b/crates/trueno-sparse/benches/sparse_bench.rs
@@ -45,7 +45,8 @@ fn bench_spmm(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |bench, _| {
             bench.iter(|| {
                 c_out.fill(0.0);
-                csr.spmm(black_box(1.0), black_box(&b_dense), black_box(k), 0.0, &mut c_out).expect("spmm ok");
+                csr.spmm(black_box(1.0), black_box(&b_dense), black_box(k), 0.0, &mut c_out)
+                    .expect("spmm ok");
                 black_box(&c_out);
             });
         });

--- a/crates/trueno-sparse/examples/sparse_spmv.rs
+++ b/crates/trueno-sparse/examples/sparse_spmv.rs
@@ -11,14 +11,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── COO → CSR ──────────────────────────────────────────
     let coo = CooMatrix::new(
-        4, 4,
+        4,
+        4,
         vec![0, 0, 1, 2, 2, 2, 3],
         vec![0, 2, 1, 0, 2, 3, 3],
         vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
     )?;
     let csr = CsrMatrix::from_coo(&coo);
-    println!("CSR: {}×{}, {} nnz, avg {:.2} nnz/row",
-        csr.rows(), csr.cols(), csr.nnz(), csr.avg_nnz_per_row());
+    println!(
+        "CSR: {}×{}, {} nnz, avg {:.2} nnz/row",
+        csr.rows(),
+        csr.cols(),
+        csr.nnz(),
+        csr.avg_nnz_per_row()
+    );
 
     // ── SpMV ───────────────────────────────────────────────
     let x = vec![1.0, 2.0, 3.0, 4.0_f32];
@@ -62,9 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("SELL storage: {} elements (padded)", sell.storage_size());
 
     // Verify SELL matches CSR
-    let max_diff: f32 = y.iter().zip(y_sell.iter())
-        .map(|(a, b)| (a - b).abs())
-        .fold(0.0, f32::max);
+    let max_diff: f32 = y.iter().zip(y_sell.iter()).map(|(a, b)| (a - b).abs()).fold(0.0, f32::max);
     println!("SELL vs CSR max diff: {max_diff:.2e}");
 
     println!("\n=== Done ===");

--- a/crates/trueno-sparse/src/bsr.rs
+++ b/crates/trueno-sparse/src/bsr.rs
@@ -64,14 +64,7 @@ impl BsrMatrix {
                 val_len: values.len(),
             });
         }
-        Ok(Self {
-            block_rows,
-            block_cols,
-            block_size,
-            offsets,
-            col_indices,
-            values,
-        })
+        Ok(Self { block_rows, block_cols, block_size, offsets, col_indices, values })
     }
 
     /// Create BSR from a dense matrix.
@@ -112,14 +105,7 @@ impl BsrMatrix {
             offsets[bi + 1] = col_indices.len() as u32;
         }
 
-        Self {
-            block_rows: br,
-            block_cols: bc,
-            block_size,
-            offsets,
-            col_indices,
-            values,
-        }
+        Self { block_rows: br, block_cols: bc, block_size, offsets, col_indices, values }
     }
 
     /// Convert to CSR format.

--- a/crates/trueno-sparse/src/coo.rs
+++ b/crates/trueno-sparse/src/coo.rs
@@ -52,31 +52,17 @@ impl<T: Clone> CooMatrix<T> {
 
         for (i, &row) in row_indices.iter().enumerate() {
             if row as usize >= rows {
-                return Err(SparseError::RowOutOfBounds {
-                    row,
-                    rows,
-                    position: i,
-                });
+                return Err(SparseError::RowOutOfBounds { row, rows, position: i });
             }
         }
 
         for (i, &col) in col_indices.iter().enumerate() {
             if col as usize >= cols {
-                return Err(SparseError::ColumnOutOfBounds {
-                    col,
-                    cols,
-                    position: i,
-                });
+                return Err(SparseError::ColumnOutOfBounds { col, cols, position: i });
             }
         }
 
-        Ok(Self {
-            rows,
-            cols,
-            row_indices,
-            col_indices,
-            values,
-        })
+        Ok(Self { rows, cols, row_indices, col_indices, values })
     }
 
     /// Number of stored nonzero entries.
@@ -88,12 +74,6 @@ impl<T: Clone> CooMatrix<T> {
     /// Create an empty COO matrix.
     #[must_use]
     pub fn empty(rows: usize, cols: usize) -> Self {
-        Self {
-            rows,
-            cols,
-            row_indices: Vec::new(),
-            col_indices: Vec::new(),
-            values: Vec::new(),
-        }
+        Self { rows, cols, row_indices: Vec::new(), col_indices: Vec::new(), values: Vec::new() }
     }
 }

--- a/crates/trueno-sparse/src/csr.rs
+++ b/crates/trueno-sparse/src/csr.rs
@@ -47,13 +47,7 @@ impl<T: Clone + Default> CsrMatrix<T> {
         values: Vec<T>,
     ) -> Result<Self, SparseError> {
         validate_csr_invariants(rows, cols, &offsets, &col_indices, values.len())?;
-        Ok(Self {
-            rows,
-            cols,
-            offsets,
-            col_indices,
-            values,
-        })
+        Ok(Self { rows, cols, offsets, col_indices, values })
     }
 
     /// Convert from COO format to CSR.
@@ -121,13 +115,7 @@ impl<T: Clone + Default> CsrMatrix<T> {
             }
         }
 
-        Self {
-            rows,
-            cols,
-            offsets,
-            col_indices,
-            values,
-        }
+        Self { rows, cols, offsets, col_indices, values }
     }
 
     /// Create an identity matrix of size n.
@@ -139,13 +127,7 @@ impl<T: Clone + Default> CsrMatrix<T> {
         let offsets: Vec<u32> = (0..=n).map(|i| i as u32).collect();
         let col_indices: Vec<u32> = (0..n).map(|i| i as u32).collect();
         let values: Vec<T> = (0..n).map(|_| T::from(1.0)).collect();
-        Self {
-            rows: n,
-            cols: n,
-            offsets,
-            col_indices,
-            values,
-        }
+        Self { rows: n, cols: n, offsets, col_indices, values }
     }
 
     /// Number of rows.

--- a/crates/trueno-sparse/src/lib.rs
+++ b/crates/trueno-sparse/src/lib.rs
@@ -34,8 +34,8 @@
 //! - LAProof (Princeton): formal backward error bounds for CSR SpMV
 
 mod bsr;
-mod csr;
 mod coo;
+mod csr;
 mod error;
 mod ops;
 mod sell;
@@ -46,11 +46,11 @@ pub use bsr::BsrMatrix;
 pub use coo::CooMatrix;
 pub use csr::CsrMatrix;
 pub use error::SparseError;
-pub use ops::{ScalarBackend, SparseBackend, SparseOps};
 #[cfg(target_arch = "x86_64")]
 pub use ops::Avx2Backend;
 #[cfg(target_arch = "aarch64")]
 pub use ops::NeonBackend;
+pub use ops::{ScalarBackend, SparseBackend, SparseOps};
 pub use sell::SellMatrix;
 pub use spgemm::spgemm;
 pub use validate::validate_csr_invariants;

--- a/crates/trueno-sparse/src/ops.rs
+++ b/crates/trueno-sparse/src/ops.rs
@@ -24,13 +24,7 @@ use crate::error::SparseError;
 /// available backend at runtime.
 pub trait SparseBackend {
     /// Perform SpMV: `y = alpha * A * x + beta * y` using this backend.
-    fn spmv_kernel(
-        a: &CsrMatrix<f32>,
-        alpha: f32,
-        x: &[f32],
-        beta: f32,
-        y: &mut [f32],
-    );
+    fn spmv_kernel(a: &CsrMatrix<f32>, alpha: f32, x: &[f32], beta: f32, y: &mut [f32]);
 
     /// Perform SpMM: `C = alpha * A * B + beta * C` using this backend.
     ///

--- a/crates/trueno-sparse/src/sell.rs
+++ b/crates/trueno-sparse/src/sell.rs
@@ -62,15 +62,7 @@ impl SellMatrix {
             slice_widths.push(max_len as u32);
 
             // Store in column-major order within the slice
-            fill_slice_data(
-                csr,
-                row_start,
-                actual_rows,
-                c,
-                max_len,
-                &mut col_indices,
-                &mut values,
-            );
+            fill_slice_data(csr, row_start, actual_rows, c, max_len, &mut col_indices, &mut values);
 
             let slice_elements = c * max_len;
             let offset = slice_offsets.last().copied().unwrap_or(0);
@@ -94,13 +86,7 @@ impl SellMatrix {
     /// # Errors
     ///
     /// Returns error on dimension mismatch.
-    pub fn spmv(
-        &self,
-        alpha: f32,
-        x: &[f32],
-        beta: f32,
-        y: &mut [f32],
-    ) -> Result<(), SparseError> {
+    pub fn spmv(&self, alpha: f32, x: &[f32], beta: f32, y: &mut [f32]) -> Result<(), SparseError> {
         if x.len() != self.cols {
             return Err(SparseError::SpMVDimensionMismatch {
                 matrix_cols: self.cols,

--- a/crates/trueno-sparse/src/spgemm.rs
+++ b/crates/trueno-sparse/src/spgemm.rs
@@ -23,10 +23,7 @@ use crate::error::SparseError;
 /// Returns error if A.cols() != B.rows().
 pub fn spgemm(a: &CsrMatrix<f32>, b: &CsrMatrix<f32>) -> Result<CsrMatrix<f32>, SparseError> {
     if a.cols() != b.rows() {
-        return Err(SparseError::SpMVDimensionMismatch {
-            matrix_cols: a.cols(),
-            x_len: b.rows(),
-        });
+        return Err(SparseError::SpMVDimensionMismatch { matrix_cols: a.cols(), x_len: b.rows() });
     }
 
     let m = a.rows();

--- a/crates/trueno-sparse/src/tests.rs
+++ b/crates/trueno-sparse/src/tests.rs
@@ -11,8 +11,9 @@ use crate::*;
 #[test]
 fn test_reject_non_monotonic_offsets() {
     let result = CsrMatrix::<f32>::new(
-        3, 3,
-        vec![0, 2, 1, 3],  // non-monotonic: offsets[1]=2 > offsets[2]=1
+        3,
+        3,
+        vec![0, 2, 1, 3], // non-monotonic: offsets[1]=2 > offsets[2]=1
         vec![0, 1, 0],
         vec![1.0, 2.0, 3.0],
     );
@@ -26,8 +27,9 @@ fn test_reject_non_monotonic_offsets() {
 #[test]
 fn test_reject_nonzero_first_offset() {
     let result = CsrMatrix::<f32>::new(
-        2, 2,
-        vec![1, 2, 3],  // offsets[0] != 0
+        2,
+        2,
+        vec![1, 2, 3], // offsets[0] != 0
         vec![0, 1, 0],
         vec![1.0, 2.0, 3.0],
     );
@@ -41,8 +43,9 @@ fn test_reject_nonzero_first_offset() {
 #[test]
 fn test_reject_offsets_nnz_mismatch() {
     let result = CsrMatrix::<f32>::new(
-        2, 2,
-        vec![0, 1, 5],  // offsets[2]=5 but only 2 elements
+        2,
+        2,
+        vec![0, 1, 5], // offsets[2]=5 but only 2 elements
         vec![0, 1],
         vec![1.0, 2.0],
     );
@@ -56,8 +59,9 @@ fn test_reject_offsets_nnz_mismatch() {
 #[test]
 fn test_reject_wrong_offsets_length() {
     let result = CsrMatrix::<f32>::new(
-        3, 3,
-        vec![0, 1],  // length 2, expected 4 (rows+1)
+        3,
+        3,
+        vec![0, 1], // length 2, expected 4 (rows+1)
         vec![0],
         vec![1.0],
     );
@@ -75,9 +79,10 @@ fn test_reject_wrong_offsets_length() {
 #[test]
 fn test_reject_column_out_of_bounds() {
     let result = CsrMatrix::<f32>::new(
-        2, 3,
+        2,
+        3,
         vec![0, 1, 2],
-        vec![0, 5],  // col=5 >= cols=3
+        vec![0, 5], // col=5 >= cols=3
         vec![1.0, 2.0],
     );
     assert!(result.is_err());
@@ -90,7 +95,7 @@ fn test_reject_column_out_of_bounds() {
 #[test]
 fn test_spmv_dimension_mismatch() {
     let a = CsrMatrix::<f32>::new(2, 3, vec![0, 1, 2], vec![0, 1], vec![1.0, 2.0]).unwrap();
-    let x = vec![1.0, 2.0];  // length 2, but cols=3
+    let x = vec![1.0, 2.0]; // length 2, but cols=3
     let mut y = vec![0.0; 2];
     let result = a.spmv(1.0, &x, 0.0, &mut y);
     assert!(result.is_err());
@@ -100,7 +105,7 @@ fn test_spmv_dimension_mismatch() {
 fn test_spmv_output_dimension_mismatch() {
     let a = CsrMatrix::<f32>::new(2, 3, vec![0, 1, 2], vec![0, 1], vec![1.0, 2.0]).unwrap();
     let x = vec![1.0, 2.0, 3.0];
-    let mut y = vec![0.0; 5];  // length 5, but rows=2
+    let mut y = vec![0.0; 5]; // length 5, but rows=2
     let result = a.spmv(1.0, &x, 0.0, &mut y);
     assert!(result.is_err());
 }
@@ -122,7 +127,8 @@ fn test_spmv_identity() {
         assert!(
             (y[i] - x[i]).abs() < 1e-7,
             "Identity SpMV failed at i={i}: y={}, x={}",
-            y[i], x[i]
+            y[i],
+            x[i]
         );
     }
 }
@@ -147,11 +153,13 @@ fn test_spmv_sparse_matrix() {
     //      [0, 3, 0],
     //      [4, 0, 5]]
     let a = CsrMatrix::<f32>::new(
-        3, 3,
+        3,
+        3,
         vec![0, 2, 3, 5],
         vec![0, 2, 1, 0, 2],
         vec![1.0, 2.0, 3.0, 4.0, 5.0],
-    ).unwrap();
+    )
+    .unwrap();
 
     let x = vec![1.0, 2.0, 3.0];
     let mut y = vec![0.0; 3];
@@ -171,12 +179,7 @@ fn test_spmv_empty_rows() {
     // A = [[0, 0],
     //      [1, 0],
     //      [0, 0]]
-    let a = CsrMatrix::<f32>::new(
-        3, 2,
-        vec![0, 0, 1, 1],
-        vec![0],
-        vec![1.0],
-    ).unwrap();
+    let a = CsrMatrix::<f32>::new(3, 2, vec![0, 0, 1, 1], vec![0], vec![1.0]).unwrap();
 
     let x = vec![5.0, 3.0];
     let mut y = vec![0.0; 3];
@@ -193,12 +196,9 @@ fn test_spmv_empty_rows() {
 
 #[test]
 fn test_coo_to_csr_basic() {
-    let coo = CooMatrix::new(
-        3, 3,
-        vec![0, 1, 2, 0],
-        vec![0, 1, 2, 2],
-        vec![1.0_f32, 2.0, 3.0, 4.0],
-    ).unwrap();
+    let coo =
+        CooMatrix::new(3, 3, vec![0, 1, 2, 0], vec![0, 1, 2, 2], vec![1.0_f32, 2.0, 3.0, 4.0])
+            .unwrap();
 
     let csr = CsrMatrix::from_coo(&coo);
     assert_eq!(csr.rows(), 3);
@@ -282,12 +282,7 @@ fn test_spmm_sparse() {
 
 #[test]
 fn test_to_dense_roundtrip() {
-    let coo = CooMatrix::new(
-        2, 3,
-        vec![0, 0, 1],
-        vec![0, 2, 1],
-        vec![1.0_f32, 2.0, 3.0],
-    ).unwrap();
+    let coo = CooMatrix::new(2, 3, vec![0, 0, 1], vec![0, 2, 1], vec![1.0_f32, 2.0, 3.0]).unwrap();
 
     let csr = CsrMatrix::from_coo(&coo);
     let dense = csr.to_dense();
@@ -308,12 +303,8 @@ fn test_to_dense_roundtrip() {
 #[test]
 fn test_avg_nnz_per_row() {
     // 3 rows, 5 nonzeros
-    let a = CsrMatrix::<f32>::new(
-        3, 3,
-        vec![0, 2, 3, 5],
-        vec![0, 1, 2, 0, 1],
-        vec![1.0; 5],
-    ).unwrap();
+    let a =
+        CsrMatrix::<f32>::new(3, 3, vec![0, 2, 3, 5], vec![0, 1, 2, 0, 1], vec![1.0; 5]).unwrap();
     let avg = a.avg_nnz_per_row();
     assert!((avg - 5.0 / 3.0).abs() < 1e-10);
 }
@@ -321,12 +312,8 @@ fn test_avg_nnz_per_row() {
 #[test]
 fn test_row_length_variance() {
     // Row lengths: [2, 1, 2], mean = 5/3
-    let a = CsrMatrix::<f32>::new(
-        3, 3,
-        vec![0, 2, 3, 5],
-        vec![0, 1, 2, 0, 1],
-        vec![1.0; 5],
-    ).unwrap();
+    let a =
+        CsrMatrix::<f32>::new(3, 3, vec![0, 2, 3, 5], vec![0, 1, 2, 0, 1], vec![1.0; 5]).unwrap();
     let var = a.row_length_variance();
     // Variance = ((2-5/3)^2 + (1-5/3)^2 + (2-5/3)^2) / 3
     //          = (1/9 + 4/9 + 1/9) / 3 = 6/27 = 2/9
@@ -350,15 +337,17 @@ mod proptests {
 
     /// Generate a random CSR matrix via COO.
     fn arb_csr(max_dim: usize, max_nnz: usize) -> impl Strategy<Value = CsrMatrix<f32>> {
-        (1..=max_dim, 1..=max_dim, 0..=max_nnz).prop_flat_map(|(rows, cols, nnz)| {
-            let row_idx = proptest::collection::vec(0..rows as u32, nnz);
-            let col_idx = proptest::collection::vec(0..cols as u32, nnz);
-            let vals = proptest::collection::vec(-100.0_f32..100.0, nnz);
-            (Just(rows), Just(cols), row_idx, col_idx, vals)
-        }).prop_map(|(rows, cols, ri, ci, vals)| {
-            let coo = CooMatrix::new(rows, cols, ri, ci, vals).unwrap();
-            CsrMatrix::from_coo(&coo)
-        })
+        (1..=max_dim, 1..=max_dim, 0..=max_nnz)
+            .prop_flat_map(|(rows, cols, nnz)| {
+                let row_idx = proptest::collection::vec(0..rows as u32, nnz);
+                let col_idx = proptest::collection::vec(0..cols as u32, nnz);
+                let vals = proptest::collection::vec(-100.0_f32..100.0, nnz);
+                (Just(rows), Just(cols), row_idx, col_idx, vals)
+            })
+            .prop_map(|(rows, cols, ri, ci, vals)| {
+                let coo = CooMatrix::new(rows, cols, ri, ci, vals).unwrap();
+                CsrMatrix::from_coo(&coo)
+            })
     }
 
     proptest! {
@@ -551,12 +540,7 @@ fn test_bsr_alpha_beta() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_spgemm_identity() -> Result<(), Box<dyn std::error::Error>> {
     // A * I = A
-    let a = CsrMatrix::new(
-        2, 2,
-        vec![0, 1, 2],
-        vec![0, 1],
-        vec![3.0_f32, 5.0],
-    )?;
+    let a = CsrMatrix::new(2, 2, vec![0, 1, 2], vec![0, 1], vec![3.0_f32, 5.0])?;
     let eye = CsrMatrix::<f32>::identity(2);
     let c = crate::spgemm::spgemm(&a, &eye)?;
     let dense = c.to_dense();
@@ -570,12 +554,7 @@ fn test_spgemm_identity() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_spgemm_identity_left() -> Result<(), Box<dyn std::error::Error>> {
     // I * A = A
-    let a = CsrMatrix::new(
-        3, 3,
-        vec![0, 2, 3, 4],
-        vec![0, 2, 1, 0],
-        vec![1.0_f32, 2.0, 3.0, 4.0],
-    )?;
+    let a = CsrMatrix::new(3, 3, vec![0, 2, 3, 4], vec![0, 2, 1, 0], vec![1.0_f32, 2.0, 3.0, 4.0])?;
     let eye = CsrMatrix::<f32>::identity(3);
     let c = crate::spgemm::spgemm(&eye, &a)?;
     assert_eq!(c.to_dense(), a.to_dense());
@@ -642,7 +621,8 @@ fn test_sell_identity_spmv() -> Result<(), Box<dyn std::error::Error>> {
 fn test_sell_matches_csr_spmv() -> Result<(), Box<dyn std::error::Error>> {
     // Sparse matrix with variable row lengths
     let csr = CsrMatrix::new(
-        4, 4,
+        4,
+        4,
         vec![0, 2, 3, 5, 6],
         vec![0, 1, 2, 1, 3, 0],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0_f32],
@@ -660,7 +640,8 @@ fn test_sell_matches_csr_spmv() -> Result<(), Box<dyn std::error::Error>> {
         assert!(
             (y_csr[i] - y_sell[i]).abs() < 1e-5,
             "SELL vs CSR mismatch at {i}: csr={}, sell={}",
-            y_csr[i], y_sell[i]
+            y_csr[i],
+            y_sell[i]
         );
     }
     Ok(())
@@ -692,12 +673,7 @@ fn test_sell_dimension_mismatch() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_sell_properties() -> Result<(), Box<dyn std::error::Error>> {
-    let csr = CsrMatrix::new(
-        3, 3,
-        vec![0, 2, 3, 3],
-        vec![0, 1, 2],
-        vec![1.0, 2.0, 3.0_f32],
-    )?;
+    let csr = CsrMatrix::new(3, 3, vec![0, 2, 3, 3], vec![0, 1, 2], vec![1.0, 2.0, 3.0_f32])?;
     let sell = SellMatrix::from_csr(&csr, 2);
     assert_eq!(sell.rows(), 3);
     assert_eq!(sell.cols(), 3);
@@ -712,12 +688,7 @@ use crate::ops::{ScalarBackend, SparseBackend};
 #[test]
 fn test_scalar_backend_spmv() -> Result<(), Box<dyn std::error::Error>> {
     // 3×3 identity via scalar backend
-    let csr = CsrMatrix::new(
-        3, 3,
-        vec![0, 1, 2, 3],
-        vec![0, 1, 2],
-        vec![1.0, 1.0, 1.0_f32],
-    )?;
+    let csr = CsrMatrix::new(3, 3, vec![0, 1, 2, 3], vec![0, 1, 2], vec![1.0, 1.0, 1.0_f32])?;
     let x = [2.0, 3.0, 4.0_f32];
     let mut y = [0.0_f32; 3];
     ScalarBackend::spmv_kernel(&csr, 1.0, &x, 0.0, &mut y);
@@ -729,12 +700,7 @@ fn test_scalar_backend_spmv() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_scalar_backend_alpha_beta() -> Result<(), Box<dyn std::error::Error>> {
-    let csr = CsrMatrix::new(
-        2, 2,
-        vec![0, 1, 2],
-        vec![0, 1],
-        vec![3.0, 5.0_f32],
-    )?;
+    let csr = CsrMatrix::new(2, 2, vec![0, 1, 2], vec![0, 1], vec![3.0, 5.0_f32])?;
     let x = [1.0, 1.0_f32];
     let mut y = [10.0, 20.0_f32];
     ScalarBackend::spmv_kernel(&csr, 2.0, &x, 0.5, &mut y);

--- a/crates/trueno-sparse/src/validate.rs
+++ b/crates/trueno-sparse/src/validate.rs
@@ -54,28 +54,18 @@ pub fn validate_csr_invariants(
     // 4. Last offset matches nnz
     let nnz = col_indices.len();
     if offsets[rows] as usize != nnz {
-        return Err(SparseError::OffsetNnzMismatch {
-            offset_last: offsets[rows],
-            nnz,
-        });
+        return Err(SparseError::OffsetNnzMismatch { offset_last: offsets[rows], nnz });
     }
 
     // col_indices and values must match
     if nnz != values_len {
-        return Err(SparseError::LengthMismatch {
-            col_len: nnz,
-            val_len: values_len,
-        });
+        return Err(SparseError::LengthMismatch { col_len: nnz, val_len: values_len });
     }
 
     // 5. Column indices in bounds
     for (i, &col) in col_indices.iter().enumerate() {
         if col as usize >= cols {
-            return Err(SparseError::ColumnOutOfBounds {
-                col,
-                cols,
-                position: i,
-            });
+            return Err(SparseError::ColumnOutOfBounds { col, cols, position: i });
         }
     }
 

--- a/crates/trueno-tensor/benches/tensor_bench.rs
+++ b/crates/trueno-tensor/benches/tensor_bench.rs
@@ -2,9 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use trueno_tensor::{einsum, matmul, Tensor};
 
 fn make_matrix(m: usize, n: usize) -> Tensor {
-    let data: Vec<f32> = (0..m * n)
-        .map(|i| ((i * 7 + 3) % 97) as f32 / 97.0)
-        .collect();
+    let data: Vec<f32> = (0..m * n).map(|i| ((i * 7 + 3) % 97) as f32 / 97.0).collect();
     Tensor::new(vec![m, n], data).expect("valid tensor")
 }
 

--- a/crates/trueno-tensor/examples/tensor_demo.rs
+++ b/crates/trueno-tensor/examples/tensor_demo.rs
@@ -10,8 +10,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let b = Tensor::new(vec![3, 2], vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0])?;
     let c = matmul(&a, &b)?;
     println!("Matrix multiply (2x3 * 3x2):");
-    println!("  C[0,0]={}, C[0,1]={}, C[1,0]={}, C[1,1]={}\n",
-        c.get(&[0, 0]), c.get(&[0, 1]), c.get(&[1, 0]), c.get(&[1, 1]));
+    println!(
+        "  C[0,0]={}, C[0,1]={}, C[1,0]={}, C[1,1]={}\n",
+        c.get(&[0, 0]),
+        c.get(&[0, 1]),
+        c.get(&[1, 0]),
+        c.get(&[1, 1])
+    );
 
     // Outer product: i,j->ij
     let u = Tensor::new(vec![3], vec![1.0, 2.0, 3.0])?;
@@ -21,11 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  shape={:?}, data={:?}\n", op.shape(), op.data());
 
     // Trace
-    let eye = Tensor::new(vec![3, 3], vec![
-        1.0, 0.0, 0.0,
-        0.0, 2.0, 0.0,
-        0.0, 0.0, 3.0,
-    ])?;
+    let eye = Tensor::new(vec![3, 3], vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0])?;
     let tr = trace(&eye)?;
     println!("Trace of diag(1,2,3) = {tr}\n");
 
@@ -44,14 +45,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // N-ary einsum: chain of 3 matmuls
     let ma = Tensor::new(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])?;
-    let mb = Tensor::new(
-        vec![3, 4],
-        vec![1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0],
-    )?;
-    let mc = Tensor::new(
-        vec![4, 2],
-        vec![1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0],
-    )?;
+    let mb =
+        Tensor::new(vec![3, 4], vec![1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0])?;
+    let mc = Tensor::new(vec![4, 2], vec![1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0])?;
     let chain = einsum_nary("ij,jk,kl->il", &[&ma, &mb, &mc])?;
     println!("N-ary einsum (3 matmuls, 2×3 × 3×4 × 4×2 → 2×2):");
     println!("  shape={:?}, data={:?}", chain.shape(), chain.data());

--- a/crates/trueno-tensor/src/einsum.rs
+++ b/crates/trueno-tensor/src/einsum.rs
@@ -20,23 +20,16 @@ struct EinsumPlan {
 fn parse_subscripts(subscripts: &str) -> Result<EinsumPlan, TensorError> {
     let parts: Vec<&str> = subscripts.split("->").collect();
     if parts.len() != 2 {
-        return Err(TensorError::InvalidSubscript(
-            "expected exactly one '->' separator".into(),
-        ));
+        return Err(TensorError::InvalidSubscript("expected exactly one '->' separator".into()));
     }
 
     let input_part = parts[0];
     let output_part = parts[1];
 
-    let input_labels: Vec<Vec<char>> = input_part
-        .split(',')
-        .map(|s| s.chars().collect())
-        .collect();
+    let input_labels: Vec<Vec<char>> = input_part.split(',').map(|s| s.chars().collect()).collect();
 
     if input_labels.is_empty() {
-        return Err(TensorError::InvalidSubscript(
-            "no input tensors specified".into(),
-        ));
+        return Err(TensorError::InvalidSubscript("no input tensors specified".into()));
     }
 
     for labels in &input_labels {
@@ -58,10 +51,7 @@ fn parse_subscripts(subscripts: &str) -> Result<EinsumPlan, TensorError> {
         }
     }
 
-    Ok(EinsumPlan {
-        input_labels,
-        output_labels,
-    })
+    Ok(EinsumPlan { input_labels, output_labels })
 }
 
 /// Build a map from index label to dimension size, validating consistency.
@@ -131,9 +121,7 @@ pub fn einsum_nary(subscripts: &str, inputs: &[&Tensor]) -> Result<Tensor, Tenso
     }
 
     if inputs.is_empty() {
-        return Err(TensorError::InvalidSubscript(
-            "no input tensors specified".into(),
-        ));
+        return Err(TensorError::InvalidSubscript("no input tensors specified".into()));
     }
 
     if inputs.len() == 1 {
@@ -202,8 +190,7 @@ fn intermediate_labels(
             continue;
         }
         seen.push(l);
-        let needed_later = remaining.iter().any(|r| r.contains(&l))
-            || output_labels.contains(&l);
+        let needed_later = remaining.iter().any(|r| r.contains(&l)) || output_labels.contains(&l);
         if needed_later {
             labels.push(l);
         }
@@ -242,11 +229,8 @@ fn einsum_single(plan: &EinsumPlan, a: &Tensor) -> Result<Tensor, TensorError> {
     let mut output = Tensor::zeros(out_shape);
 
     // Contracted indices: in input but not in output
-    let contracted: Vec<char> = a_labels
-        .iter()
-        .filter(|l| !out_labels.contains(l))
-        .copied()
-        .collect();
+    let contracted: Vec<char> =
+        a_labels.iter().filter(|l| !out_labels.contains(l)).copied().collect();
 
     let mut all_labels: Vec<char> = out_labels.clone();
     all_labels.extend_from_slice(&contracted);
@@ -261,11 +245,8 @@ fn einsum_single(plan: &EinsumPlan, a: &Tensor) -> Result<Tensor, TensorError> {
     let mut indices = vec![0usize; ndim];
 
     for _ in 0..total {
-        let label_vals: HashMap<char, usize> = all_labels
-            .iter()
-            .zip(indices.iter())
-            .map(|(&l, &v)| (l, v))
-            .collect();
+        let label_vals: HashMap<char, usize> =
+            all_labels.iter().zip(indices.iter()).map(|(&l, &v)| (l, v)).collect();
 
         let a_idx: Vec<usize> = a_labels.iter().map(|l| label_vals[l]).collect();
         let out_idx: Vec<usize> = out_labels.iter().map(|l| label_vals[l]).collect();
@@ -341,24 +322,12 @@ fn einsum_binary(subscripts: &str, a: &Tensor, b: &Tensor) -> Result<Tensor, Ten
     }
 
     // Compute output shape
-    let out_shape: Vec<usize> = out_labels
-        .iter()
-        .map(|l| index_sizes[l])
-        .collect();
+    let out_shape: Vec<usize> = out_labels.iter().map(|l| index_sizes[l]).collect();
 
     let mut output = Tensor::zeros(out_shape);
 
     // Compute contraction via explicit nested iteration
-    contract_tensors(
-        a,
-        b,
-        &mut output,
-        a_labels,
-        b_labels,
-        out_labels,
-        &contracted,
-        &index_sizes,
-    );
+    contract_tensors(a, b, &mut output, a_labels, b_labels, out_labels, &contracted, &index_sizes);
 
     Ok(output)
 }
@@ -379,10 +348,7 @@ fn contract_tensors(
     let mut all_labels: Vec<char> = out_labels.to_vec();
     all_labels.extend_from_slice(contracted);
 
-    let all_sizes: Vec<usize> = all_labels
-        .iter()
-        .map(|l| index_sizes[l])
-        .collect();
+    let all_sizes: Vec<usize> = all_labels.iter().map(|l| index_sizes[l]).collect();
 
     let total: usize = all_sizes.iter().product();
     if total == 0 {
@@ -394,11 +360,8 @@ fn contract_tensors(
 
     for _ in 0..total {
         // Build label->value map
-        let label_vals: HashMap<char, usize> = all_labels
-            .iter()
-            .zip(indices.iter())
-            .map(|(&l, &v)| (l, v))
-            .collect();
+        let label_vals: HashMap<char, usize> =
+            all_labels.iter().zip(indices.iter()).map(|(&l, &v)| (l, v)).collect();
 
         // Index into A
         let a_idx: Vec<usize> = a_labels.iter().map(|l| label_vals[l]).collect();
@@ -433,9 +396,7 @@ pub fn outer(a: &Tensor, b: &Tensor) -> Result<Tensor, TensorError> {
 /// Trace via einsum: `"ii->"` but implemented as sum of diagonal.
 pub fn trace(a: &Tensor) -> Result<f32, TensorError> {
     if a.ndim() != 2 || a.shape()[0] != a.shape()[1] {
-        return Err(TensorError::InvalidSubscript(
-            "trace requires a square 2D tensor".into(),
-        ));
+        return Err(TensorError::InvalidSubscript("trace requires a square 2D tensor".into()));
     }
     let n = a.shape()[0];
     let mut sum = 0.0f32;

--- a/crates/trueno-tensor/src/error.rs
+++ b/crates/trueno-tensor/src/error.rs
@@ -28,7 +28,9 @@ pub enum TensorError {
     InvalidSubscript(String),
 
     /// Contracted dimensions don't match.
-    #[error("contracted dimension mismatch: index '{index}' has size {size_a} in A but {size_b} in B")]
+    #[error(
+        "contracted dimension mismatch: index '{index}' has size {size_a} in A but {size_b} in B"
+    )]
     ContractionDimensionMismatch {
         /// Index label.
         index: char,

--- a/crates/trueno-tensor/src/tensor.rs
+++ b/crates/trueno-tensor/src/tensor.rs
@@ -29,22 +29,14 @@ impl Tensor {
             });
         }
         let strides = compute_strides(&shape);
-        Ok(Self {
-            shape,
-            strides,
-            data,
-        })
+        Ok(Self { shape, strides, data })
     }
 
     /// Create a zero tensor with the given shape.
     pub fn zeros(shape: Vec<usize>) -> Self {
         let product: usize = shape.iter().product();
         let strides = compute_strides(&shape);
-        Self {
-            shape,
-            strides,
-            data: vec![0.0; product],
-        }
+        Self { shape, strides, data: vec![0.0; product] }
     }
 
     /// Tensor shape.
@@ -91,11 +83,7 @@ impl Tensor {
 
     /// Compute linear offset from multi-index.
     fn offset(&self, indices: &[usize]) -> usize {
-        indices
-            .iter()
-            .zip(self.strides.iter())
-            .map(|(&i, &s)| i * s)
-            .sum()
+        indices.iter().zip(self.strides.iter()).map(|(&i, &s)| i * s).sum()
     }
 
     /// Reshape tensor (must have same total elements).
@@ -145,11 +133,7 @@ impl Tensor {
             new_data[new_offset] = self.data[flat];
         }
 
-        Self {
-            shape: new_shape,
-            strides: new_strides,
-            data: new_data,
-        }
+        Self { shape: new_shape, strides: new_strides, data: new_data }
     }
 }
 

--- a/crates/trueno-tensor/src/tests.rs
+++ b/crates/trueno-tensor/src/tests.rs
@@ -125,14 +125,8 @@ fn test_einsum_trace() -> R {
 
 #[test]
 fn test_einsum_batch_matmul() -> R {
-    let a = Tensor::new(
-        vec![2, 2, 2],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
-    )?;
-    let b = Tensor::new(
-        vec![2, 2, 2],
-        vec![1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
-    )?;
+    let a = Tensor::new(vec![2, 2, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])?;
+    let b = Tensor::new(vec![2, 2, 2], vec![1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0])?;
     let c = batch_matmul(&a, &b)?;
     assert_eq!(c.shape(), &[2, 2, 2]);
     for i in 0..8 {
@@ -278,14 +272,9 @@ fn test_einsum_nary_three_inputs() -> R {
     // (A @ B) @ C = A @ (B @ C) for matmul chain
     // A=2×3, B=3×4, C=4×2
     let a = Tensor::new(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])?;
-    let b = Tensor::new(
-        vec![3, 4],
-        vec![1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0],
-    )?;
-    let c = Tensor::new(
-        vec![4, 2],
-        vec![1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0],
-    )?;
+    let b =
+        Tensor::new(vec![3, 4], vec![1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0])?;
+    let c = Tensor::new(vec![4, 2], vec![1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0])?;
 
     let result = einsum_nary("ij,jk,kl->il", &[&a, &b, &c])?;
     assert_eq!(result.shape(), &[2, 2]);

--- a/src/backends/avx2/mod.rs
+++ b/src/backends/avx2/mod.rs
@@ -17,453 +17,482 @@ impl VectorBackend for Avx2Backend {
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::add(a, b, result)
-    }}
+    unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe { ops::arithmetic::add(a, b, result) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::sub(a, b, result)
-    }}
+    unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe { ops::arithmetic::sub(a, b, result) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::mul(a, b, result)
-    }}
+    unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe { ops::arithmetic::mul(a, b, result) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::div(a, b, result)
-    }}
+    unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe { ops::arithmetic::div(a, b, result) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2,fma")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn dot(a: &[f32], b: &[f32]) -> f32 { unsafe {
-        ops::reductions::dot(a, b)
-    }}
+    unsafe fn dot(a: &[f32], b: &[f32]) -> f32 {
+        unsafe { ops::reductions::dot(a, b) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sum(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::sum(a)
-    }}
+    unsafe fn sum(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::sum(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn max(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::max(a)
-    }}
+    unsafe fn max(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::max(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn min(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::min(a)
-    }}
+    unsafe fn min(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::min(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn argmax(a: &[f32]) -> usize { unsafe {
-        ops::reductions::argmax(a)
-    }}
+    unsafe fn argmax(a: &[f32]) -> usize {
+        unsafe { ops::reductions::argmax(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn argmin(a: &[f32]) -> usize { unsafe {
-        ops::reductions::argmin(a)
-    }}
+    unsafe fn argmin(a: &[f32]) -> usize {
+        unsafe { ops::reductions::argmin(a) }
+    }
 
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sum_kahan(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::sum_kahan(a)
-    }}
+    unsafe fn sum_kahan(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::sum_kahan(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2,fma")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn norm_l2(a: &[f32]) -> f32 { unsafe {
-        if a.is_empty() {
-            return 0.0;
+    unsafe fn norm_l2(a: &[f32]) -> f32 {
+        unsafe {
+            if a.is_empty() {
+                return 0.0;
+            }
+            Self::dot(a, a).sqrt()
         }
-        Self::dot(a, a).sqrt()
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn norm_l1(a: &[f32]) -> f32 { unsafe {
-        if a.is_empty() {
-            return 0.0;
-        }
-        let len = a.len();
-        let mut i = 0;
-        let mut acc = _mm256_setzero_ps();
-        let sign_mask = _mm256_set1_ps(f32::from_bits(0x7FFF_FFFF));
+    unsafe fn norm_l1(a: &[f32]) -> f32 {
+        unsafe {
+            if a.is_empty() {
+                return 0.0;
+            }
+            let len = a.len();
+            let mut i = 0;
+            let mut acc = _mm256_setzero_ps();
+            let sign_mask = _mm256_set1_ps(f32::from_bits(0x7FFF_FFFF));
 
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let abs_va = _mm256_and_ps(va, sign_mask);
-            acc = _mm256_add_ps(acc, abs_va);
-            i += 8;
-        }
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let abs_va = _mm256_and_ps(va, sign_mask);
+                acc = _mm256_add_ps(acc, abs_va);
+                i += 8;
+            }
 
-        let mut result = {
-            let sum_halves = _mm_add_ps(_mm256_castps256_ps128(acc), _mm256_extractf128_ps(acc, 1));
-            let temp = _mm_add_ps(sum_halves, _mm_movehl_ps(sum_halves, sum_halves));
-            let temp = _mm_add_ss(temp, _mm_shuffle_ps(temp, temp, 1));
-            _mm_cvtss_f32(temp)
-        };
+            let mut result = {
+                let sum_halves =
+                    _mm_add_ps(_mm256_castps256_ps128(acc), _mm256_extractf128_ps(acc, 1));
+                let temp = _mm_add_ps(sum_halves, _mm_movehl_ps(sum_halves, sum_halves));
+                let temp = _mm_add_ss(temp, _mm_shuffle_ps(temp, temp, 1));
+                _mm_cvtss_f32(temp)
+            };
 
-        for &val in &a[i..] {
-            result += val.abs();
+            for &val in &a[i..] {
+                result += val.abs();
+            }
+            result
         }
-        result
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn norm_linf(a: &[f32]) -> f32 { unsafe {
-        if a.is_empty() {
-            return 0.0;
+    unsafe fn norm_linf(a: &[f32]) -> f32 {
+        unsafe {
+            if a.is_empty() {
+                return 0.0;
+            }
+            let len = a.len();
+            let mut i = 0;
+            let mut max_vec = _mm256_setzero_ps();
+            let sign_mask = _mm256_set1_ps(f32::from_bits(0x7FFF_FFFF));
+
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let abs_va = _mm256_and_ps(va, sign_mask);
+                max_vec = _mm256_max_ps(max_vec, abs_va);
+                i += 8;
+            }
+
+            let mut result = {
+                let max_halves =
+                    _mm_max_ps(_mm256_castps256_ps128(max_vec), _mm256_extractf128_ps(max_vec, 1));
+                let temp = _mm_max_ps(max_halves, _mm_movehl_ps(max_halves, max_halves));
+                let temp = _mm_max_ss(temp, _mm_shuffle_ps(temp, temp, 1));
+                _mm_cvtss_f32(temp)
+            };
+
+            for &val in &a[i..] {
+                let abs_val = val.abs();
+                if abs_val > result {
+                    result = abs_val;
+                }
+            }
+            result
         }
-        let len = a.len();
-        let mut i = 0;
-        let mut max_vec = _mm256_setzero_ps();
-        let sign_mask = _mm256_set1_ps(f32::from_bits(0x7FFF_FFFF));
+    }
 
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let abs_va = _mm256_and_ps(va, sign_mask);
-            max_vec = _mm256_max_ps(max_vec, abs_va);
-            i += 8;
-        }
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn scale(a: &[f32], scalar: f32, result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let scalar_vec = _mm256_set1_ps(scalar);
 
-        let mut result = {
-            let max_halves =
-                _mm_max_ps(_mm256_castps256_ps128(max_vec), _mm256_extractf128_ps(max_vec, 1));
-            let temp = _mm_max_ps(max_halves, _mm_movehl_ps(max_halves, max_halves));
-            let temp = _mm_max_ss(temp, _mm_shuffle_ps(temp, temp, 1));
-            _mm_cvtss_f32(temp)
-        };
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let vresult = _mm256_mul_ps(va, scalar_vec);
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
 
-        for &val in &a[i..] {
-            let abs_val = val.abs();
-            if abs_val > result {
-                result = abs_val;
+            while i < len {
+                result[i] = a[i] * scalar;
+                i += 1;
             }
         }
-        result
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn scale(a: &[f32], scalar: f32, result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let scalar_vec = _mm256_set1_ps(scalar);
+    unsafe fn abs(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let sign_mask = _mm256_set1_ps(f32::from_bits(0x7FFF_FFFF));
 
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let vresult = _mm256_mul_ps(va, scalar_vec);
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
-        }
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let vresult = _mm256_and_ps(va, sign_mask);
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
 
-        while i < len {
-            result[i] = a[i] * scalar;
-            i += 1;
+            for j in i..len {
+                result[j] = a[j].abs();
+            }
         }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn abs(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let sign_mask = _mm256_set1_ps(f32::from_bits(0x7FFF_FFFF));
+    unsafe fn clamp(a: &[f32], min_val: f32, max_val: f32, result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let vmin = _mm256_set1_ps(min_val);
+            let vmax = _mm256_set1_ps(max_val);
 
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let vresult = _mm256_and_ps(va, sign_mask);
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let vresult = _mm256_min_ps(_mm256_max_ps(va, vmin), vmax);
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
+
+            for j in i..len {
+                result[j] = a[j].clamp(min_val, max_val);
+            }
         }
-
-        for j in i..len {
-            result[j] = a[j].abs();
-        }
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn clamp(a: &[f32], min_val: f32, max_val: f32, result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let vmin = _mm256_set1_ps(min_val);
-        let vmax = _mm256_set1_ps(max_val);
-
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let vresult = _mm256_min_ps(_mm256_max_ps(va, vmin), vmax);
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
-        }
-
-        for j in i..len {
-            result[j] = a[j].clamp(min_val, max_val);
-        }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx2,fma")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn lerp(a: &[f32], b: &[f32], t: f32, result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let vt = _mm256_set1_ps(t);
-        let v1_minus_t = _mm256_set1_ps(1.0 - t);
+    unsafe fn lerp(a: &[f32], b: &[f32], t: f32, result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let vt = _mm256_set1_ps(t);
+            let v1_minus_t = _mm256_set1_ps(1.0 - t);
 
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let vb = _mm256_loadu_ps(b.as_ptr().add(i));
-            let vresult = _mm256_fmadd_ps(vb, vt, _mm256_mul_ps(va, v1_minus_t));
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
-        }
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let vb = _mm256_loadu_ps(b.as_ptr().add(i));
+                let vresult = _mm256_fmadd_ps(vb, vt, _mm256_mul_ps(va, v1_minus_t));
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
 
-        for j in i..len {
-            result[j] = a[j] * (1.0 - t) + b[j] * t;
+            for j in i..len {
+                result[j] = a[j] * (1.0 - t) + b[j] * t;
+            }
         }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx2,fma")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn fma(a: &[f32], b: &[f32], c: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
+    unsafe fn fma(a: &[f32], b: &[f32], c: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
 
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let vb = _mm256_loadu_ps(b.as_ptr().add(i));
-            let vc = _mm256_loadu_ps(c.as_ptr().add(i));
-            let vresult = _mm256_fmadd_ps(va, vb, vc);
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
-        }
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let vb = _mm256_loadu_ps(b.as_ptr().add(i));
+                let vc = _mm256_loadu_ps(c.as_ptr().add(i));
+                let vresult = _mm256_fmadd_ps(va, vb, vc);
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
 
-        for j in i..len {
-            result[j] = a[j] * b[j] + c[j];
+            for j in i..len {
+                result[j] = a[j] * b[j] + c[j];
+            }
         }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn relu(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let vzero = _mm256_setzero_ps();
+    unsafe fn relu(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let vzero = _mm256_setzero_ps();
 
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let vresult = _mm256_max_ps(va, vzero);
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
-        }
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let vresult = _mm256_max_ps(va, vzero);
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
 
-        for j in i..len {
-            result[j] = a[j].max(0.0);
+            for j in i..len {
+                result[j] = a[j].max(0.0);
+            }
         }
-    }}
+    }
 
     // Delegate transcendental functions to scalar backend
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn exp(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::exp(a, result)
-    }}
+    unsafe fn exp(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::exp(a, result) }
+    }
 
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sigmoid(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::sigmoid(a, result)
-    }}
+    unsafe fn sigmoid(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::sigmoid(a, result) }
+    }
 
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn gelu(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::gelu(a, result)
-    }}
+    unsafe fn gelu(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::gelu(a, result) }
+    }
 
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn swish(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::swish(a, result)
-    }}
+    unsafe fn swish(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::swish(a, result) }
+    }
 
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn tanh(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::tanh(a, result)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sqrt(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let vresult = _mm256_sqrt_ps(va);
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
-        }
-
-        for j in i..len {
-            result[j] = a[j].sqrt();
-        }
-    }}
+    unsafe fn tanh(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::tanh(a, result) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn recip(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let vone = _mm256_set1_ps(1.0);
+    unsafe fn sqrt(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
 
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let vresult = _mm256_div_ps(vone, va);
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
-        }
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let vresult = _mm256_sqrt_ps(va);
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
 
-        for j in i..len {
-            result[j] = 1.0 / a[j];
+            for j in i..len {
+                result[j] = a[j].sqrt();
+            }
         }
-    }}
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn recip(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let vone = _mm256_set1_ps(1.0);
+
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let vresult = _mm256_div_ps(vone, va);
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
+
+            for j in i..len {
+                result[j] = 1.0 / a[j];
+            }
+        }
+    }
 
     // Delegate log functions to scalar backend
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn ln(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::ln(a, result)
-    }}
+    unsafe fn ln(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::ln(a, result) }
+    }
 
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn log2(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::log2(a, result)
-    }}
+    unsafe fn log2(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::log2(a, result) }
+    }
 
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn log10(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::log10(a, result)
-    }}
+    unsafe fn log10(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::log10(a, result) }
+    }
 
     // Delegate trig functions to scalar backend
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sin(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::sin(a, result)
-    }}
+    unsafe fn sin(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::sin(a, result) }
+    }
 
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn cos(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::cos(a, result)
-    }}
+    unsafe fn cos(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::cos(a, result) }
+    }
 
     #[inline]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn tan(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::tan(a, result)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn floor(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let vresult = _mm256_floor_ps(va);
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
-        }
-
-        for j in i..len {
-            result[j] = a[j].floor();
-        }
-    }}
+    unsafe fn tan(a: &[f32], result: &mut [f32]) {
+        unsafe { super::scalar::ScalarBackend::tan(a, result) }
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn ceil(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
+    unsafe fn floor(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
 
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let vresult = _mm256_ceil_ps(va);
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
-        }
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let vresult = _mm256_floor_ps(va);
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
 
-        for j in i..len {
-            result[j] = a[j].ceil();
+            for j in i..len {
+                result[j] = a[j].floor();
+            }
         }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn round(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
+    unsafe fn ceil(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
 
-        // Round ties away from zero to match Rust's f32::round()
-        let half = _mm256_set1_ps(0.5);
-        let sign_mask = _mm256_set1_ps(f32::from_bits(0x8000_0000));
-        let abs_mask = _mm256_set1_ps(f32::from_bits(0x7FFF_FFFF));
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let vresult = _mm256_ceil_ps(va);
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
 
-        while i + 8 <= len {
-            let va = _mm256_loadu_ps(a.as_ptr().add(i));
-            let sign = _mm256_and_ps(va, sign_mask);
-            let abs_val = _mm256_and_ps(va, abs_mask);
-            let shifted = _mm256_add_ps(abs_val, half);
-            let rounded_abs = _mm256_floor_ps(shifted);
-            let vresult = _mm256_or_ps(rounded_abs, sign);
-            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-            i += 8;
+            for j in i..len {
+                result[j] = a[j].ceil();
+            }
         }
+    }
 
-        for j in i..len {
-            result[j] = a[j].round();
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn round(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+
+            // Round ties away from zero to match Rust's f32::round()
+            let half = _mm256_set1_ps(0.5);
+            let sign_mask = _mm256_set1_ps(f32::from_bits(0x8000_0000));
+            let abs_mask = _mm256_set1_ps(f32::from_bits(0x7FFF_FFFF));
+
+            while i + 8 <= len {
+                let va = _mm256_loadu_ps(a.as_ptr().add(i));
+                let sign = _mm256_and_ps(va, sign_mask);
+                let abs_val = _mm256_and_ps(va, abs_mask);
+                let shifted = _mm256_add_ps(abs_val, half);
+                let rounded_abs = _mm256_floor_ps(shifted);
+                let vresult = _mm256_or_ps(rounded_abs, sign);
+                _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+                i += 8;
+            }
+
+            for j in i..len {
+                result[j] = a[j].round();
+            }
         }
-    }}
+    }
 }

--- a/src/backends/avx2/ops/arithmetic.rs
+++ b/src/backends/avx2/ops/arithmetic.rs
@@ -7,82 +7,90 @@ use std::arch::x86_64::*;
 #[inline]
 #[target_feature(enable = "avx2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
+pub(crate) unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
 
-    while i + 8 <= len {
-        let va = _mm256_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm256_loadu_ps(b.as_ptr().add(i));
-        let vresult = _mm256_add_ps(va, vb);
-        _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-        i += 8;
-    }
+        while i + 8 <= len {
+            let va = _mm256_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm256_loadu_ps(b.as_ptr().add(i));
+            let vresult = _mm256_add_ps(va, vb);
+            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+            i += 8;
+        }
 
-    for j in i..len {
-        result[j] = a[j] + b[j];
+        for j in i..len {
+            result[j] = a[j] + b[j];
+        }
     }
-}}
+}
 
 /// AVX2 vector subtraction.
 #[inline]
 #[target_feature(enable = "avx2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
+pub(crate) unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
 
-    while i + 8 <= len {
-        let va = _mm256_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm256_loadu_ps(b.as_ptr().add(i));
-        let vresult = _mm256_sub_ps(va, vb);
-        _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-        i += 8;
-    }
+        while i + 8 <= len {
+            let va = _mm256_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm256_loadu_ps(b.as_ptr().add(i));
+            let vresult = _mm256_sub_ps(va, vb);
+            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+            i += 8;
+        }
 
-    for j in i..len {
-        result[j] = a[j] - b[j];
+        for j in i..len {
+            result[j] = a[j] - b[j];
+        }
     }
-}}
+}
 
 /// AVX2 vector multiplication.
 #[inline]
 #[target_feature(enable = "avx2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
+pub(crate) unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
 
-    while i + 8 <= len {
-        let va = _mm256_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm256_loadu_ps(b.as_ptr().add(i));
-        let vresult = _mm256_mul_ps(va, vb);
-        _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-        i += 8;
-    }
+        while i + 8 <= len {
+            let va = _mm256_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm256_loadu_ps(b.as_ptr().add(i));
+            let vresult = _mm256_mul_ps(va, vb);
+            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+            i += 8;
+        }
 
-    for j in i..len {
-        result[j] = a[j] * b[j];
+        for j in i..len {
+            result[j] = a[j] * b[j];
+        }
     }
-}}
+}
 
 /// AVX2 vector division.
 #[inline]
 #[target_feature(enable = "avx2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
+pub(crate) unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
 
-    while i + 8 <= len {
-        let va = _mm256_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm256_loadu_ps(b.as_ptr().add(i));
-        let vresult = _mm256_div_ps(va, vb);
-        _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
-        i += 8;
-    }
+        while i + 8 <= len {
+            let va = _mm256_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm256_loadu_ps(b.as_ptr().add(i));
+            let vresult = _mm256_div_ps(va, vb);
+            _mm256_storeu_ps(result.as_mut_ptr().add(i), vresult);
+            i += 8;
+        }
 
-    for j in i..len {
-        result[j] = a[j] / b[j];
+        for j in i..len {
+            result[j] = a[j] / b[j];
+        }
     }
-}}
+}

--- a/src/backends/avx2/ops/reductions.rs
+++ b/src/backends/avx2/ops/reductions.rs
@@ -9,238 +9,252 @@ use crate::backends::VectorBackend;
 #[inline]
 #[target_feature(enable = "avx2,fma")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn dot(a: &[f32], b: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
+pub(crate) unsafe fn dot(a: &[f32], b: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
 
-    let mut acc0 = _mm256_setzero_ps();
-    let mut acc1 = _mm256_setzero_ps();
-    let mut acc2 = _mm256_setzero_ps();
-    let mut acc3 = _mm256_setzero_ps();
+        let mut acc0 = _mm256_setzero_ps();
+        let mut acc1 = _mm256_setzero_ps();
+        let mut acc2 = _mm256_setzero_ps();
+        let mut acc3 = _mm256_setzero_ps();
 
-    while i + 32 <= len {
-        let va0 = _mm256_loadu_ps(a.as_ptr().add(i));
-        let vb0 = _mm256_loadu_ps(b.as_ptr().add(i));
-        let va1 = _mm256_loadu_ps(a.as_ptr().add(i + 8));
-        let vb1 = _mm256_loadu_ps(b.as_ptr().add(i + 8));
-        let va2 = _mm256_loadu_ps(a.as_ptr().add(i + 16));
-        let vb2 = _mm256_loadu_ps(b.as_ptr().add(i + 16));
-        let va3 = _mm256_loadu_ps(a.as_ptr().add(i + 24));
-        let vb3 = _mm256_loadu_ps(b.as_ptr().add(i + 24));
+        while i + 32 <= len {
+            let va0 = _mm256_loadu_ps(a.as_ptr().add(i));
+            let vb0 = _mm256_loadu_ps(b.as_ptr().add(i));
+            let va1 = _mm256_loadu_ps(a.as_ptr().add(i + 8));
+            let vb1 = _mm256_loadu_ps(b.as_ptr().add(i + 8));
+            let va2 = _mm256_loadu_ps(a.as_ptr().add(i + 16));
+            let vb2 = _mm256_loadu_ps(b.as_ptr().add(i + 16));
+            let va3 = _mm256_loadu_ps(a.as_ptr().add(i + 24));
+            let vb3 = _mm256_loadu_ps(b.as_ptr().add(i + 24));
 
-        acc0 = _mm256_fmadd_ps(va0, vb0, acc0);
-        acc1 = _mm256_fmadd_ps(va1, vb1, acc1);
-        acc2 = _mm256_fmadd_ps(va2, vb2, acc2);
-        acc3 = _mm256_fmadd_ps(va3, vb3, acc3);
+            acc0 = _mm256_fmadd_ps(va0, vb0, acc0);
+            acc1 = _mm256_fmadd_ps(va1, vb1, acc1);
+            acc2 = _mm256_fmadd_ps(va2, vb2, acc2);
+            acc3 = _mm256_fmadd_ps(va3, vb3, acc3);
 
-        i += 32;
+            i += 32;
+        }
+
+        while i + 8 <= len {
+            let va = _mm256_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm256_loadu_ps(b.as_ptr().add(i));
+            acc0 = _mm256_fmadd_ps(va, vb, acc0);
+            i += 8;
+        }
+
+        let acc01 = _mm256_add_ps(acc0, acc1);
+        let acc23 = _mm256_add_ps(acc2, acc3);
+        let acc = _mm256_add_ps(acc01, acc23);
+
+        let mut result = {
+            let sum_halves = _mm_add_ps(_mm256_castps256_ps128(acc), _mm256_extractf128_ps(acc, 1));
+            let temp = _mm_add_ps(sum_halves, _mm_movehl_ps(sum_halves, sum_halves));
+            let temp = _mm_add_ss(temp, _mm_shuffle_ps(temp, temp, 1));
+            _mm_cvtss_f32(temp)
+        };
+
+        result += a[i..].iter().zip(&b[i..]).map(|(x, y)| x * y).sum::<f32>();
+        result
     }
-
-    while i + 8 <= len {
-        let va = _mm256_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm256_loadu_ps(b.as_ptr().add(i));
-        acc0 = _mm256_fmadd_ps(va, vb, acc0);
-        i += 8;
-    }
-
-    let acc01 = _mm256_add_ps(acc0, acc1);
-    let acc23 = _mm256_add_ps(acc2, acc3);
-    let acc = _mm256_add_ps(acc01, acc23);
-
-    let mut result = {
-        let sum_halves = _mm_add_ps(_mm256_castps256_ps128(acc), _mm256_extractf128_ps(acc, 1));
-        let temp = _mm_add_ps(sum_halves, _mm_movehl_ps(sum_halves, sum_halves));
-        let temp = _mm_add_ss(temp, _mm_shuffle_ps(temp, temp, 1));
-        _mm_cvtss_f32(temp)
-    };
-
-    result += a[i..].iter().zip(&b[i..]).map(|(x, y)| x * y).sum::<f32>();
-    result
-}}
+}
 
 /// AVX2 vector sum.
 #[inline]
 #[target_feature(enable = "avx2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn sum(a: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut acc = _mm256_setzero_ps();
+pub(crate) unsafe fn sum(a: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut acc = _mm256_setzero_ps();
 
-    while i + 8 <= len {
-        let va = _mm256_loadu_ps(a.as_ptr().add(i));
-        acc = _mm256_add_ps(acc, va);
-        i += 8;
+        while i + 8 <= len {
+            let va = _mm256_loadu_ps(a.as_ptr().add(i));
+            acc = _mm256_add_ps(acc, va);
+            i += 8;
+        }
+
+        let mut result = {
+            let sum_halves = _mm_add_ps(_mm256_castps256_ps128(acc), _mm256_extractf128_ps(acc, 1));
+            let temp = _mm_add_ps(sum_halves, _mm_movehl_ps(sum_halves, sum_halves));
+            let temp = _mm_add_ss(temp, _mm_shuffle_ps(temp, temp, 1));
+            _mm_cvtss_f32(temp)
+        };
+
+        result += a[i..].iter().sum::<f32>();
+        result
     }
-
-    let mut result = {
-        let sum_halves = _mm_add_ps(_mm256_castps256_ps128(acc), _mm256_extractf128_ps(acc, 1));
-        let temp = _mm_add_ps(sum_halves, _mm_movehl_ps(sum_halves, sum_halves));
-        let temp = _mm_add_ss(temp, _mm_shuffle_ps(temp, temp, 1));
-        _mm_cvtss_f32(temp)
-    };
-
-    result += a[i..].iter().sum::<f32>();
-    result
-}}
+}
 
 /// AVX2 vector max.
 #[inline]
 #[target_feature(enable = "avx2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn max(a: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut vmax = _mm256_set1_ps(a[0]);
+pub(crate) unsafe fn max(a: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut vmax = _mm256_set1_ps(a[0]);
 
-    while i + 8 <= len {
-        let va = _mm256_loadu_ps(a.as_ptr().add(i));
-        vmax = _mm256_max_ps(vmax, va);
-        i += 8;
-    }
-
-    let mut result = {
-        let max_halves = _mm_max_ps(_mm256_castps256_ps128(vmax), _mm256_extractf128_ps(vmax, 1));
-        let temp = _mm_max_ps(max_halves, _mm_movehl_ps(max_halves, max_halves));
-        let temp = _mm_max_ss(temp, _mm_shuffle_ps(temp, temp, 1));
-        _mm_cvtss_f32(temp)
-    };
-
-    for &val in &a[i..] {
-        if val > result {
-            result = val;
+        while i + 8 <= len {
+            let va = _mm256_loadu_ps(a.as_ptr().add(i));
+            vmax = _mm256_max_ps(vmax, va);
+            i += 8;
         }
+
+        let mut result = {
+            let max_halves =
+                _mm_max_ps(_mm256_castps256_ps128(vmax), _mm256_extractf128_ps(vmax, 1));
+            let temp = _mm_max_ps(max_halves, _mm_movehl_ps(max_halves, max_halves));
+            let temp = _mm_max_ss(temp, _mm_shuffle_ps(temp, temp, 1));
+            _mm_cvtss_f32(temp)
+        };
+
+        for &val in &a[i..] {
+            if val > result {
+                result = val;
+            }
+        }
+        result
     }
-    result
-}}
+}
 
 /// AVX2 vector min.
 #[inline]
 #[target_feature(enable = "avx2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn min(a: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut vmin = _mm256_set1_ps(a[0]);
+pub(crate) unsafe fn min(a: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut vmin = _mm256_set1_ps(a[0]);
 
-    while i + 8 <= len {
-        let va = _mm256_loadu_ps(a.as_ptr().add(i));
-        vmin = _mm256_min_ps(vmin, va);
-        i += 8;
-    }
-
-    let mut result = {
-        let min_halves = _mm_min_ps(_mm256_castps256_ps128(vmin), _mm256_extractf128_ps(vmin, 1));
-        let temp = _mm_min_ps(min_halves, _mm_movehl_ps(min_halves, min_halves));
-        let temp = _mm_min_ss(temp, _mm_shuffle_ps(temp, temp, 1));
-        _mm_cvtss_f32(temp)
-    };
-
-    for &val in &a[i..] {
-        if val < result {
-            result = val;
+        while i + 8 <= len {
+            let va = _mm256_loadu_ps(a.as_ptr().add(i));
+            vmin = _mm256_min_ps(vmin, va);
+            i += 8;
         }
+
+        let mut result = {
+            let min_halves =
+                _mm_min_ps(_mm256_castps256_ps128(vmin), _mm256_extractf128_ps(vmin, 1));
+            let temp = _mm_min_ps(min_halves, _mm_movehl_ps(min_halves, min_halves));
+            let temp = _mm_min_ss(temp, _mm_shuffle_ps(temp, temp, 1));
+            _mm_cvtss_f32(temp)
+        };
+
+        for &val in &a[i..] {
+            if val < result {
+                result = val;
+            }
+        }
+        result
     }
-    result
-}}
+}
 
 /// AVX2 argmax.
 #[inline]
 #[target_feature(enable = "avx2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn argmax(a: &[f32]) -> usize { unsafe {
-    let len = a.len();
-    let mut max_idx: usize = 0;
-    let mut max_val = a[0];
-    let mut i = 0;
+pub(crate) unsafe fn argmax(a: &[f32]) -> usize {
+    unsafe {
+        let len = a.len();
+        let mut max_idx: usize = 0;
+        let mut max_val = a[0];
+        let mut i = 0;
 
-    let mut vmax = _mm256_set1_ps(a[0]);
-    let mut vidx_max = _mm256_setzero_ps();
-    let vidx_inc = _mm256_set1_ps(8.0);
-    let mut vcurrent_idx = _mm256_set_ps(7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0);
+        let mut vmax = _mm256_set1_ps(a[0]);
+        let mut vidx_max = _mm256_setzero_ps();
+        let vidx_inc = _mm256_set1_ps(8.0);
+        let mut vcurrent_idx = _mm256_set_ps(7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0);
 
-    while i + 8 <= len {
-        let va = _mm256_loadu_ps(a.as_ptr().add(i));
-        let mask = _mm256_cmp_ps(va, vmax, _CMP_GT_OQ);
-        vmax = _mm256_blendv_ps(vmax, va, mask);
-        vidx_max = _mm256_blendv_ps(vidx_max, vcurrent_idx, mask);
-        vcurrent_idx = _mm256_add_ps(vcurrent_idx, vidx_inc);
-        i += 8;
-    }
-
-    // Extract max from vector
-    let mut vals = [0.0f32; 8];
-    let mut idxs = [0.0f32; 8];
-    _mm256_storeu_ps(vals.as_mut_ptr(), vmax);
-    _mm256_storeu_ps(idxs.as_mut_ptr(), vidx_max);
-
-    for j in 0..8 {
-        if vals[j] > max_val {
-            max_val = vals[j];
-            max_idx = idxs[j] as usize;
+        while i + 8 <= len {
+            let va = _mm256_loadu_ps(a.as_ptr().add(i));
+            let mask = _mm256_cmp_ps(va, vmax, _CMP_GT_OQ);
+            vmax = _mm256_blendv_ps(vmax, va, mask);
+            vidx_max = _mm256_blendv_ps(vidx_max, vcurrent_idx, mask);
+            vcurrent_idx = _mm256_add_ps(vcurrent_idx, vidx_inc);
+            i += 8;
         }
-    }
 
-    // Check remaining elements
-    for (j, &val) in a[i..].iter().enumerate() {
-        if val > max_val {
-            max_val = val;
-            max_idx = i + j;
+        // Extract max from vector
+        let mut vals = [0.0f32; 8];
+        let mut idxs = [0.0f32; 8];
+        _mm256_storeu_ps(vals.as_mut_ptr(), vmax);
+        _mm256_storeu_ps(idxs.as_mut_ptr(), vidx_max);
+
+        for j in 0..8 {
+            if vals[j] > max_val {
+                max_val = vals[j];
+                max_idx = idxs[j] as usize;
+            }
         }
-    }
 
-    max_idx
-}}
+        // Check remaining elements
+        for (j, &val) in a[i..].iter().enumerate() {
+            if val > max_val {
+                max_val = val;
+                max_idx = i + j;
+            }
+        }
+
+        max_idx
+    }
+}
 
 /// AVX2 argmin.
 #[inline]
 #[target_feature(enable = "avx2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn argmin(a: &[f32]) -> usize { unsafe {
-    let len = a.len();
-    let mut min_idx: usize = 0;
-    let mut min_val = a[0];
-    let mut i = 0;
+pub(crate) unsafe fn argmin(a: &[f32]) -> usize {
+    unsafe {
+        let len = a.len();
+        let mut min_idx: usize = 0;
+        let mut min_val = a[0];
+        let mut i = 0;
 
-    let mut vmin = _mm256_set1_ps(a[0]);
-    let mut vidx_min = _mm256_setzero_ps();
-    let vidx_inc = _mm256_set1_ps(8.0);
-    let mut vcurrent_idx = _mm256_set_ps(7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0);
+        let mut vmin = _mm256_set1_ps(a[0]);
+        let mut vidx_min = _mm256_setzero_ps();
+        let vidx_inc = _mm256_set1_ps(8.0);
+        let mut vcurrent_idx = _mm256_set_ps(7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0);
 
-    while i + 8 <= len {
-        let va = _mm256_loadu_ps(a.as_ptr().add(i));
-        let mask = _mm256_cmp_ps(va, vmin, _CMP_LT_OQ);
-        vmin = _mm256_blendv_ps(vmin, va, mask);
-        vidx_min = _mm256_blendv_ps(vidx_min, vcurrent_idx, mask);
-        vcurrent_idx = _mm256_add_ps(vcurrent_idx, vidx_inc);
-        i += 8;
-    }
-
-    let mut vals = [0.0f32; 8];
-    let mut idxs = [0.0f32; 8];
-    _mm256_storeu_ps(vals.as_mut_ptr(), vmin);
-    _mm256_storeu_ps(idxs.as_mut_ptr(), vidx_min);
-
-    for j in 0..8 {
-        if vals[j] < min_val {
-            min_val = vals[j];
-            min_idx = idxs[j] as usize;
+        while i + 8 <= len {
+            let va = _mm256_loadu_ps(a.as_ptr().add(i));
+            let mask = _mm256_cmp_ps(va, vmin, _CMP_LT_OQ);
+            vmin = _mm256_blendv_ps(vmin, va, mask);
+            vidx_min = _mm256_blendv_ps(vidx_min, vcurrent_idx, mask);
+            vcurrent_idx = _mm256_add_ps(vcurrent_idx, vidx_inc);
+            i += 8;
         }
-    }
 
-    for (j, &val) in a[i..].iter().enumerate() {
-        if val < min_val {
-            min_val = val;
-            min_idx = i + j;
+        let mut vals = [0.0f32; 8];
+        let mut idxs = [0.0f32; 8];
+        _mm256_storeu_ps(vals.as_mut_ptr(), vmin);
+        _mm256_storeu_ps(idxs.as_mut_ptr(), vidx_min);
+
+        for j in 0..8 {
+            if vals[j] < min_val {
+                min_val = vals[j];
+                min_idx = idxs[j] as usize;
+            }
         }
-    }
 
-    min_idx
-}}
+        for (j, &val) in a[i..].iter().enumerate() {
+            if val < min_val {
+                min_val = val;
+                min_idx = i + j;
+            }
+        }
+
+        min_idx
+    }
+}
 
 /// Kahan sum for numerical stability (delegates to scalar).
 #[inline]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn sum_kahan(a: &[f32]) -> f32 { unsafe {
-    crate::backends::scalar::ScalarBackend::sum_kahan(a)
-}}
+pub(crate) unsafe fn sum_kahan(a: &[f32]) -> f32 {
+    unsafe { crate::backends::scalar::ScalarBackend::sum_kahan(a) }
+}

--- a/src/backends/avx512/mod.rs
+++ b/src/backends/avx512/mod.rs
@@ -27,295 +27,326 @@ impl VectorBackend for Avx512Backend {
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::add(a, b, result);
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::sub(a, b, result);
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::mul(a, b, result);
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::div(a, b, result);
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn dot(a: &[f32], b: &[f32]) -> f32 { unsafe {
-        ops::reductions::dot(a, b)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sum(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::sum(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn max(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::max(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn min(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::min(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn argmax(a: &[f32]) -> usize { unsafe {
-        ops::reductions::argmax(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn argmin(a: &[f32]) -> usize { unsafe {
-        ops::reductions::argmin(a)
-    }}
-
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sum_kahan(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::sum_kahan(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn norm_l2(a: &[f32]) -> f32 { unsafe {
-        if a.is_empty() {
-            return 0.0;
+    unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::arithmetic::add(a, b, result);
         }
-        let len = a.len();
-        let mut i = 0;
-        let mut acc = _mm512_setzero_ps();
-        while i + 16 <= len {
-            let va = _mm512_loadu_ps(a.as_ptr().add(i));
-            acc = _mm512_add_ps(acc, _mm512_mul_ps(va, va));
-            i += 16;
-        }
-        let mut sum_sq = _mm512_reduce_add_ps(acc);
-        for &val in &a[i..] {
-            sum_sq += val * val;
-        }
-        sum_sq.sqrt()
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn norm_l1(a: &[f32]) -> f32 { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let sign_mask = _mm512_set1_ps(f32::from_bits(0x7FFF_FFFF));
-        let mut acc = _mm512_setzero_ps();
-        while i + 16 <= len {
-            acc = _mm512_add_ps(acc, _mm512_and_ps(_mm512_loadu_ps(a.as_ptr().add(i)), sign_mask));
-            i += 16;
+    unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::arithmetic::sub(a, b, result);
         }
-        let mut result = _mm512_reduce_add_ps(acc);
-        for &val in &a[i..] {
-            result += val.abs();
-        }
-        result
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn norm_linf(a: &[f32]) -> f32 { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let sign_mask = _mm512_set1_ps(f32::from_bits(0x7FFF_FFFF));
-        let mut max_vec = _mm512_setzero_ps();
-        while i + 16 <= len {
-            max_vec = _mm512_max_ps(
-                max_vec,
-                _mm512_and_ps(_mm512_loadu_ps(a.as_ptr().add(i)), sign_mask),
-            );
-            i += 16;
+    unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::arithmetic::mul(a, b, result);
         }
-        let mut result = _mm512_reduce_max_ps(max_vec);
-        for &val in &a[i..] {
-            let abs_val = val.abs();
-            if abs_val > result {
-                result = abs_val;
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::arithmetic::div(a, b, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn dot(a: &[f32], b: &[f32]) -> f32 {
+        unsafe { ops::reductions::dot(a, b) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn sum(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::sum(a) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn max(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::max(a) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn min(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::min(a) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn argmax(a: &[f32]) -> usize {
+        unsafe { ops::reductions::argmax(a) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn argmin(a: &[f32]) -> usize {
+        unsafe { ops::reductions::argmin(a) }
+    }
+
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn sum_kahan(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::sum_kahan(a) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn norm_l2(a: &[f32]) -> f32 {
+        unsafe {
+            if a.is_empty() {
+                return 0.0;
+            }
+            let len = a.len();
+            let mut i = 0;
+            let mut acc = _mm512_setzero_ps();
+            while i + 16 <= len {
+                let va = _mm512_loadu_ps(a.as_ptr().add(i));
+                acc = _mm512_add_ps(acc, _mm512_mul_ps(va, va));
+                i += 16;
+            }
+            let mut sum_sq = _mm512_reduce_add_ps(acc);
+            for &val in &a[i..] {
+                sum_sq += val * val;
+            }
+            sum_sq.sqrt()
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn norm_l1(a: &[f32]) -> f32 {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let sign_mask = _mm512_set1_ps(f32::from_bits(0x7FFF_FFFF));
+            let mut acc = _mm512_setzero_ps();
+            while i + 16 <= len {
+                acc = _mm512_add_ps(
+                    acc,
+                    _mm512_and_ps(_mm512_loadu_ps(a.as_ptr().add(i)), sign_mask),
+                );
+                i += 16;
+            }
+            let mut result = _mm512_reduce_add_ps(acc);
+            for &val in &a[i..] {
+                result += val.abs();
+            }
+            result
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn norm_linf(a: &[f32]) -> f32 {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let sign_mask = _mm512_set1_ps(f32::from_bits(0x7FFF_FFFF));
+            let mut max_vec = _mm512_setzero_ps();
+            while i + 16 <= len {
+                max_vec = _mm512_max_ps(
+                    max_vec,
+                    _mm512_and_ps(_mm512_loadu_ps(a.as_ptr().add(i)), sign_mask),
+                );
+                i += 16;
+            }
+            let mut result = _mm512_reduce_max_ps(max_vec);
+            for &val in &a[i..] {
+                let abs_val = val.abs();
+                if abs_val > result {
+                    result = abs_val;
+                }
+            }
+            result
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn scale(a: &[f32], scalar: f32, result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let scalar_vec = _mm512_set1_ps(scalar);
+            while i + 16 <= len {
+                _mm512_storeu_ps(
+                    result.as_mut_ptr().add(i),
+                    _mm512_mul_ps(_mm512_loadu_ps(a.as_ptr().add(i)), scalar_vec),
+                );
+                i += 16;
+            }
+            for j in i..len {
+                result[j] = a[j] * scalar;
             }
         }
-        result
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn scale(a: &[f32], scalar: f32, result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let scalar_vec = _mm512_set1_ps(scalar);
-        while i + 16 <= len {
-            _mm512_storeu_ps(
-                result.as_mut_ptr().add(i),
-                _mm512_mul_ps(_mm512_loadu_ps(a.as_ptr().add(i)), scalar_vec),
-            );
-            i += 16;
+    unsafe fn abs(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let sign_mask = _mm512_set1_ps(f32::from_bits(0x7FFF_FFFF));
+            while i + 16 <= len {
+                _mm512_storeu_ps(
+                    result.as_mut_ptr().add(i),
+                    _mm512_and_ps(_mm512_loadu_ps(a.as_ptr().add(i)), sign_mask),
+                );
+                i += 16;
+            }
+            for j in i..len {
+                result[j] = a[j].abs();
+            }
         }
-        for j in i..len {
-            result[j] = a[j] * scalar;
-        }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn abs(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let sign_mask = _mm512_set1_ps(f32::from_bits(0x7FFF_FFFF));
-        while i + 16 <= len {
-            _mm512_storeu_ps(
-                result.as_mut_ptr().add(i),
-                _mm512_and_ps(_mm512_loadu_ps(a.as_ptr().add(i)), sign_mask),
-            );
-            i += 16;
+    unsafe fn clamp(a: &[f32], min_val: f32, max_val: f32, result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let min_vec = _mm512_set1_ps(min_val);
+            let max_vec = _mm512_set1_ps(max_val);
+            while i + 16 <= len {
+                let va = _mm512_loadu_ps(a.as_ptr().add(i));
+                _mm512_storeu_ps(
+                    result.as_mut_ptr().add(i),
+                    _mm512_min_ps(_mm512_max_ps(va, min_vec), max_vec),
+                );
+                i += 16;
+            }
+            for j in i..len {
+                result[j] = a[j].max(min_val).min(max_val);
+            }
         }
-        for j in i..len {
-            result[j] = a[j].abs();
-        }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn clamp(a: &[f32], min_val: f32, max_val: f32, result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let min_vec = _mm512_set1_ps(min_val);
-        let max_vec = _mm512_set1_ps(max_val);
-        while i + 16 <= len {
-            let va = _mm512_loadu_ps(a.as_ptr().add(i));
-            _mm512_storeu_ps(
-                result.as_mut_ptr().add(i),
-                _mm512_min_ps(_mm512_max_ps(va, min_vec), max_vec),
-            );
-            i += 16;
+    unsafe fn lerp(a: &[f32], b: &[f32], t: f32, result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let t_vec = _mm512_set1_ps(t);
+            while i + 16 <= len {
+                let va = _mm512_loadu_ps(a.as_ptr().add(i));
+                let vb = _mm512_loadu_ps(b.as_ptr().add(i));
+                _mm512_storeu_ps(
+                    result.as_mut_ptr().add(i),
+                    _mm512_fmadd_ps(t_vec, _mm512_sub_ps(vb, va), va),
+                );
+                i += 16;
+            }
+            for j in i..len {
+                result[j] = a[j] + t * (b[j] - a[j]);
+            }
         }
-        for j in i..len {
-            result[j] = a[j].max(min_val).min(max_val);
-        }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn lerp(a: &[f32], b: &[f32], t: f32, result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let t_vec = _mm512_set1_ps(t);
-        while i + 16 <= len {
-            let va = _mm512_loadu_ps(a.as_ptr().add(i));
-            let vb = _mm512_loadu_ps(b.as_ptr().add(i));
-            _mm512_storeu_ps(
-                result.as_mut_ptr().add(i),
-                _mm512_fmadd_ps(t_vec, _mm512_sub_ps(vb, va), va),
-            );
-            i += 16;
+    unsafe fn fma(a: &[f32], b: &[f32], c: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            while i + 16 <= len {
+                let va = _mm512_loadu_ps(a.as_ptr().add(i));
+                let vb = _mm512_loadu_ps(b.as_ptr().add(i));
+                let vc = _mm512_loadu_ps(c.as_ptr().add(i));
+                _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_fmadd_ps(va, vb, vc));
+                i += 16;
+            }
+            for j in i..len {
+                result[j] = a[j] * b[j] + c[j];
+            }
         }
-        for j in i..len {
-            result[j] = a[j] + t * (b[j] - a[j]);
-        }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn fma(a: &[f32], b: &[f32], c: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        while i + 16 <= len {
-            let va = _mm512_loadu_ps(a.as_ptr().add(i));
-            let vb = _mm512_loadu_ps(b.as_ptr().add(i));
-            let vc = _mm512_loadu_ps(c.as_ptr().add(i));
-            _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_fmadd_ps(va, vb, vc));
-            i += 16;
+    unsafe fn relu(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let zero = _mm512_setzero_ps();
+            while i + 16 <= len {
+                _mm512_storeu_ps(
+                    result.as_mut_ptr().add(i),
+                    _mm512_max_ps(_mm512_loadu_ps(a.as_ptr().add(i)), zero),
+                );
+                i += 16;
+            }
+            for j in i..len {
+                result[j] = a[j].max(0.0);
+            }
         }
-        for j in i..len {
-            result[j] = a[j] * b[j] + c[j];
-        }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn relu(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let zero = _mm512_setzero_ps();
-        while i + 16 <= len {
-            _mm512_storeu_ps(
-                result.as_mut_ptr().add(i),
-                _mm512_max_ps(_mm512_loadu_ps(a.as_ptr().add(i)), zero),
-            );
-            i += 16;
+    unsafe fn exp(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let ln2 = _mm512_set1_ps(std::f32::consts::LN_2);
+            let inv_ln2 = _mm512_set1_ps(1.0 / std::f32::consts::LN_2);
+            let one = _mm512_set1_ps(1.0);
+            let c2 = _mm512_set1_ps(0.5);
+            let c3 = _mm512_set1_ps(0.166_666_67);
+            let c4 = _mm512_set1_ps(0.041_666_668);
+            let c5 = _mm512_set1_ps(0.008_333_334);
+            while i + 16 <= len {
+                let x = _mm512_loadu_ps(a.as_ptr().add(i));
+                let k = _mm512_cvtps_epi32(_mm512_mul_ps(x, inv_ln2));
+                let kf = _mm512_cvtepi32_ps(k);
+                let r = _mm512_sub_ps(x, _mm512_mul_ps(kf, ln2));
+                let mut poly = _mm512_fmadd_ps(r, c5, one);
+                poly = _mm512_fmadd_ps(r, _mm512_fmadd_ps(r, poly, c4), one);
+                poly = _mm512_fmadd_ps(r, _mm512_fmadd_ps(r, poly, c3), one);
+                poly = _mm512_fmadd_ps(r, _mm512_fmadd_ps(r, poly, c2), one);
+                poly = _mm512_fmadd_ps(r, poly, one);
+                let exp_k = _mm512_castsi512_ps(_mm512_slli_epi32(
+                    _mm512_add_epi32(k, _mm512_set1_epi32(127)),
+                    23,
+                ));
+                _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_mul_ps(poly, exp_k));
+                i += 16;
+            }
+            for j in i..len {
+                result[j] = a[j].exp();
+            }
         }
-        for j in i..len {
-            result[j] = a[j].max(0.0);
-        }
-    }}
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn exp(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let ln2 = _mm512_set1_ps(std::f32::consts::LN_2);
-        let inv_ln2 = _mm512_set1_ps(1.0 / std::f32::consts::LN_2);
-        let one = _mm512_set1_ps(1.0);
-        let c2 = _mm512_set1_ps(0.5);
-        let c3 = _mm512_set1_ps(0.166_666_67);
-        let c4 = _mm512_set1_ps(0.041_666_668);
-        let c5 = _mm512_set1_ps(0.008_333_334);
-        while i + 16 <= len {
-            let x = _mm512_loadu_ps(a.as_ptr().add(i));
-            let k = _mm512_cvtps_epi32(_mm512_mul_ps(x, inv_ln2));
-            let kf = _mm512_cvtepi32_ps(k);
-            let r = _mm512_sub_ps(x, _mm512_mul_ps(kf, ln2));
-            let mut poly = _mm512_fmadd_ps(r, c5, one);
-            poly = _mm512_fmadd_ps(r, _mm512_fmadd_ps(r, poly, c4), one);
-            poly = _mm512_fmadd_ps(r, _mm512_fmadd_ps(r, poly, c3), one);
-            poly = _mm512_fmadd_ps(r, _mm512_fmadd_ps(r, poly, c2), one);
-            poly = _mm512_fmadd_ps(r, poly, one);
-            let exp_k = _mm512_castsi512_ps(_mm512_slli_epi32(
-                _mm512_add_epi32(k, _mm512_set1_epi32(127)),
-                23,
-            ));
-            _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_mul_ps(poly, exp_k));
-            i += 16;
-        }
-        for j in i..len {
-            result[j] = a[j].exp();
-        }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx512f")]
@@ -360,77 +391,99 @@ impl VectorBackend for Avx512Backend {
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sqrt(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        while i + 16 <= len {
-            _mm512_storeu_ps(
-                result.as_mut_ptr().add(i),
-                _mm512_sqrt_ps(_mm512_loadu_ps(a.as_ptr().add(i))),
-            );
-            i += 16;
+    unsafe fn sqrt(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            while i + 16 <= len {
+                _mm512_storeu_ps(
+                    result.as_mut_ptr().add(i),
+                    _mm512_sqrt_ps(_mm512_loadu_ps(a.as_ptr().add(i))),
+                );
+                i += 16;
+            }
+            for j in i..len {
+                result[j] = a[j].sqrt();
+            }
         }
-        for j in i..len {
-            result[j] = a[j].sqrt();
-        }
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "avx512f")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn recip(a: &[f32], result: &mut [f32]) { unsafe {
-        let len = a.len();
-        let mut i = 0;
-        let one = _mm512_set1_ps(1.0);
-        while i + 16 <= len {
-            _mm512_storeu_ps(
-                result.as_mut_ptr().add(i),
-                _mm512_div_ps(one, _mm512_loadu_ps(a.as_ptr().add(i))),
-            );
-            i += 16;
+    unsafe fn recip(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            let len = a.len();
+            let mut i = 0;
+            let one = _mm512_set1_ps(1.0);
+            while i + 16 <= len {
+                _mm512_storeu_ps(
+                    result.as_mut_ptr().add(i),
+                    _mm512_div_ps(one, _mm512_loadu_ps(a.as_ptr().add(i))),
+                );
+                i += 16;
+            }
+            for j in i..len {
+                result[j] = a[j].recip();
+            }
         }
-        for j in i..len {
-            result[j] = a[j].recip();
-        }
-    }}
+    }
 
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn ln(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::ln(a, result);
-    }}
+    unsafe fn ln(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::ln(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn log2(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::log2(a, result);
-    }}
+    unsafe fn log2(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::log2(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn log10(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::log10(a, result);
-    }}
+    unsafe fn log10(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::log10(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sin(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::sin(a, result);
-    }}
+    unsafe fn sin(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::sin(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn cos(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::cos(a, result);
-    }}
+    unsafe fn cos(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::cos(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn tan(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::tan(a, result);
-    }}
+    unsafe fn tan(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::tan(a, result);
+        }
+    }
 
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn floor(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::floor(a, result);
-    }}
+    unsafe fn floor(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::floor(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn ceil(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::ceil(a, result);
-    }}
+    unsafe fn ceil(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::ceil(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn round(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::round(a, result);
-    }}
+    unsafe fn round(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::round(a, result);
+        }
+    }
 }
 
 #[cfg(all(test, target_arch = "x86_64"))]

--- a/src/backends/avx512/ops/arithmetic.rs
+++ b/src/backends/avx512/ops/arithmetic.rs
@@ -7,70 +7,78 @@ use std::arch::x86_64::*;
 #[inline]
 #[target_feature(enable = "avx512f")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    while i + 16 <= len {
-        let va = _mm512_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm512_loadu_ps(b.as_ptr().add(i));
-        _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_add_ps(va, vb));
-        i += 16;
+pub(crate) unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        while i + 16 <= len {
+            let va = _mm512_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm512_loadu_ps(b.as_ptr().add(i));
+            _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_add_ps(va, vb));
+            i += 16;
+        }
+        for j in i..len {
+            result[j] = a[j] + b[j];
+        }
     }
-    for j in i..len {
-        result[j] = a[j] + b[j];
-    }
-}}
+}
 
 /// AVX-512 vector subtraction.
 #[inline]
 #[target_feature(enable = "avx512f")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    while i + 16 <= len {
-        let va = _mm512_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm512_loadu_ps(b.as_ptr().add(i));
-        _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_sub_ps(va, vb));
-        i += 16;
+pub(crate) unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        while i + 16 <= len {
+            let va = _mm512_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm512_loadu_ps(b.as_ptr().add(i));
+            _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_sub_ps(va, vb));
+            i += 16;
+        }
+        for j in i..len {
+            result[j] = a[j] - b[j];
+        }
     }
-    for j in i..len {
-        result[j] = a[j] - b[j];
-    }
-}}
+}
 
 /// AVX-512 vector multiplication.
 #[inline]
 #[target_feature(enable = "avx512f")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    while i + 16 <= len {
-        let va = _mm512_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm512_loadu_ps(b.as_ptr().add(i));
-        _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_mul_ps(va, vb));
-        i += 16;
+pub(crate) unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        while i + 16 <= len {
+            let va = _mm512_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm512_loadu_ps(b.as_ptr().add(i));
+            _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_mul_ps(va, vb));
+            i += 16;
+        }
+        for j in i..len {
+            result[j] = a[j] * b[j];
+        }
     }
-    for j in i..len {
-        result[j] = a[j] * b[j];
-    }
-}}
+}
 
 /// AVX-512 vector division.
 #[inline]
 #[target_feature(enable = "avx512f")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    while i + 16 <= len {
-        let va = _mm512_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm512_loadu_ps(b.as_ptr().add(i));
-        _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_div_ps(va, vb));
-        i += 16;
+pub(crate) unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        while i + 16 <= len {
+            let va = _mm512_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm512_loadu_ps(b.as_ptr().add(i));
+            _mm512_storeu_ps(result.as_mut_ptr().add(i), _mm512_div_ps(va, vb));
+            i += 16;
+        }
+        for j in i..len {
+            result[j] = a[j] / b[j];
+        }
     }
-    for j in i..len {
-        result[j] = a[j] / b[j];
-    }
-}}
+}

--- a/src/backends/avx512/ops/reductions.rs
+++ b/src/backends/avx512/ops/reductions.rs
@@ -7,87 +7,95 @@ use std::arch::x86_64::*;
 #[inline]
 #[target_feature(enable = "avx512f")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn dot(a: &[f32], b: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut acc = _mm512_setzero_ps();
+pub(crate) unsafe fn dot(a: &[f32], b: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut acc = _mm512_setzero_ps();
 
-    while i + 16 <= len {
-        let va = _mm512_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm512_loadu_ps(b.as_ptr().add(i));
-        acc = _mm512_fmadd_ps(va, vb, acc);
-        i += 16;
+        while i + 16 <= len {
+            let va = _mm512_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm512_loadu_ps(b.as_ptr().add(i));
+            acc = _mm512_fmadd_ps(va, vb, acc);
+            i += 16;
+        }
+
+        let mut result = _mm512_reduce_add_ps(acc);
+        result += a[i..].iter().zip(&b[i..]).map(|(x, y)| x * y).sum::<f32>();
+        result
     }
-
-    let mut result = _mm512_reduce_add_ps(acc);
-    result += a[i..].iter().zip(&b[i..]).map(|(x, y)| x * y).sum::<f32>();
-    result
-}}
+}
 
 /// AVX-512 vector sum.
 #[inline]
 #[target_feature(enable = "avx512f")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn sum(a: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut acc = _mm512_setzero_ps();
+pub(crate) unsafe fn sum(a: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut acc = _mm512_setzero_ps();
 
-    while i + 16 <= len {
-        acc = _mm512_add_ps(acc, _mm512_loadu_ps(a.as_ptr().add(i)));
-        i += 16;
+        while i + 16 <= len {
+            acc = _mm512_add_ps(acc, _mm512_loadu_ps(a.as_ptr().add(i)));
+            i += 16;
+        }
+
+        let mut result = _mm512_reduce_add_ps(acc);
+        result += a[i..].iter().sum::<f32>();
+        result
     }
-
-    let mut result = _mm512_reduce_add_ps(acc);
-    result += a[i..].iter().sum::<f32>();
-    result
-}}
+}
 
 /// AVX-512 vector max.
 #[inline]
 #[target_feature(enable = "avx512f")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn max(a: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut vmax = _mm512_set1_ps(a[0]);
+pub(crate) unsafe fn max(a: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut vmax = _mm512_set1_ps(a[0]);
 
-    while i + 16 <= len {
-        vmax = _mm512_max_ps(vmax, _mm512_loadu_ps(a.as_ptr().add(i)));
-        i += 16;
-    }
-
-    let mut result = _mm512_reduce_max_ps(vmax);
-    for &val in &a[i..] {
-        if val > result {
-            result = val;
+        while i + 16 <= len {
+            vmax = _mm512_max_ps(vmax, _mm512_loadu_ps(a.as_ptr().add(i)));
+            i += 16;
         }
+
+        let mut result = _mm512_reduce_max_ps(vmax);
+        for &val in &a[i..] {
+            if val > result {
+                result = val;
+            }
+        }
+        result
     }
-    result
-}}
+}
 
 /// AVX-512 vector min.
 #[inline]
 #[target_feature(enable = "avx512f")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn min(a: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut vmin = _mm512_set1_ps(a[0]);
+pub(crate) unsafe fn min(a: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut vmin = _mm512_set1_ps(a[0]);
 
-    while i + 16 <= len {
-        vmin = _mm512_min_ps(vmin, _mm512_loadu_ps(a.as_ptr().add(i)));
-        i += 16;
-    }
-
-    let mut result = _mm512_reduce_min_ps(vmin);
-    for &val in &a[i..] {
-        if val < result {
-            result = val;
+        while i + 16 <= len {
+            vmin = _mm512_min_ps(vmin, _mm512_loadu_ps(a.as_ptr().add(i)));
+            i += 16;
         }
+
+        let mut result = _mm512_reduce_min_ps(vmin);
+        for &val in &a[i..] {
+            if val < result {
+                result = val;
+            }
+        }
+        result
     }
-    result
-}}
+}
 
 /// AVX-512 argmax.
 #[inline]

--- a/src/backends/gpu/batch/execute/dispatch.rs
+++ b/src/backends/gpu/batch/execute/dispatch.rs
@@ -50,11 +50,10 @@ impl GpuCommandBatch {
 
         // Get or create cached pipeline
         if !cache.contains_key(&key) {
-            let shader =
-                self.device.device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                    label: Some(&format!("{} Shader", label)),
-                    source: wgpu::ShaderSource::Wgsl(shader_source.into()),
-                });
+            let shader = self.device.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(&format!("{} Shader", label)),
+                source: wgpu::ShaderSource::Wgsl(shader_source.into()),
+            });
 
             let mut layout_entries = vec![
                 wgpu::BindGroupLayoutEntry {
@@ -193,11 +192,10 @@ impl GpuCommandBatch {
 
         // Get or create cached pipeline
         if !cache.contains_key(&key) {
-            let shader =
-                self.device.device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                    label: Some(&format!("{} Shader", label)),
-                    source: wgpu::ShaderSource::Wgsl(shader_source.into()),
-                });
+            let shader = self.device.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(&format!("{} Shader", label)),
+                source: wgpu::ShaderSource::Wgsl(shader_source.into()),
+            });
 
             let bind_group_layout =
                 self.device.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -331,11 +329,10 @@ impl GpuCommandBatch {
 
         // Get or create cached pipeline
         if !cache.contains_key(&key) {
-            let shader =
-                self.device.device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                    label: Some(&format!("{} Shader", label)),
-                    source: wgpu::ShaderSource::Wgsl(shader_source.into()),
-                });
+            let shader = self.device.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(&format!("{} Shader", label)),
+                source: wgpu::ShaderSource::Wgsl(shader_source.into()),
+            });
 
             let bind_group_layout =
                 self.device.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {

--- a/src/backends/gpu/batch/mod.rs
+++ b/src/backends/gpu/batch/mod.rs
@@ -103,14 +103,7 @@ pub(crate) enum GpuOp {
 
     /// Matrix multiplication: C = A × B
     /// A is M×K, B is K×N, C is M×N (all row-major)
-    Matmul {
-        a: BufferId,
-        b: BufferId,
-        output: BufferId,
-        m: u32,
-        k: u32,
-        n: u32,
-    },
+    Matmul { a: BufferId, b: BufferId, output: BufferId, m: u32, k: u32, n: u32 },
 }
 
 /// Command batch for async GPU execution
@@ -382,14 +375,7 @@ impl GpuCommandBatch {
     pub fn import_buffer(&mut self, buffer: Arc<wgpu::Buffer>, size: usize) -> BufferId {
         let id = BufferId(self.next_buffer_id);
         self.next_buffer_id += 1;
-        self.buffers.insert(
-            id,
-            BufferInfo {
-                size,
-                data: None,
-                gpu_buffer: Some(buffer),
-            },
-        );
+        self.buffers.insert(id, BufferInfo { size, data: None, gpu_buffer: Some(buffer) });
         id
     }
 

--- a/src/backends/q4k/gemv/avx2.rs
+++ b/src/backends/q4k/gemv/avx2.rs
@@ -17,31 +17,40 @@ pub(crate) unsafe fn matmul_q4k_f32_avx2(
     input: &[f32],
     out_dim: usize,
     in_dim: usize,
-) -> Vec<f32> { unsafe {
-    use std::arch::x86_64::*;
+) -> Vec<f32> {
+    unsafe {
+        use std::arch::x86_64::*;
 
-    let num_blocks_per_row = (in_dim + SUPER_BLOCK_SIZE - 1) / SUPER_BLOCK_SIZE;
-    let row_bytes = num_blocks_per_row * SUPER_BLOCK_BYTES;
-    let low_mask = _mm256_set1_epi32(0x0F);
+        let num_blocks_per_row = (in_dim + SUPER_BLOCK_SIZE - 1) / SUPER_BLOCK_SIZE;
+        let row_bytes = num_blocks_per_row * SUPER_BLOCK_BYTES;
+        let low_mask = _mm256_set1_epi32(0x0F);
 
-    let mut output = vec![0.0f32; out_dim];
+        let mut output = vec![0.0f32; out_dim];
 
-    for out_idx in 0..out_dim {
-        let row_start = out_idx * row_bytes;
-        let mut acc = _mm256_setzero_ps();
+        for out_idx in 0..out_dim {
+            let row_start = out_idx * row_bytes;
+            let mut acc = _mm256_setzero_ps();
 
-        for sb_idx in 0..num_blocks_per_row {
-            let sb_start = row_start + sb_idx * SUPER_BLOCK_BYTES;
-            let sb_data = &q4k_data[sb_start..sb_start + SUPER_BLOCK_BYTES];
-            let input_offset = sb_idx * SUPER_BLOCK_SIZE;
-            process_q4k_superblock_avx2(sb_data, input, input_offset, in_dim, low_mask, &mut acc);
+            for sb_idx in 0..num_blocks_per_row {
+                let sb_start = row_start + sb_idx * SUPER_BLOCK_BYTES;
+                let sb_data = &q4k_data[sb_start..sb_start + SUPER_BLOCK_BYTES];
+                let input_offset = sb_idx * SUPER_BLOCK_SIZE;
+                process_q4k_superblock_avx2(
+                    sb_data,
+                    input,
+                    input_offset,
+                    in_dim,
+                    low_mask,
+                    &mut acc,
+                );
+            }
+
+            output[out_idx] = hsum_avx2(acc);
         }
 
-        output[out_idx] = hsum_avx2(acc);
+        output
     }
-
-    output
-}}
+}
 
 /// Process one Q4K super-block row with AVX2 and accumulate into `acc`.
 #[cfg(target_arch = "x86_64")]
@@ -54,59 +63,61 @@ pub(crate) unsafe fn process_q4k_superblock_avx2(
     in_dim: usize,
     low_mask: std::arch::x86_64::__m256i,
     acc: &mut std::arch::x86_64::__m256,
-) { unsafe {
-    use std::arch::x86_64::*;
+) {
+    unsafe {
+        use std::arch::x86_64::*;
 
-    let (d, dmin, scales, mins) = parse_q4k_header(sb_data);
-    let qs = sb_data.get(16..144).expect("Q4_K: need ≥144 bytes for qs");
+        let (d, dmin, scales, mins) = parse_q4k_header(sb_data);
+        let qs = sb_data.get(16..144).expect("Q4_K: need ≥144 bytes for qs");
 
-    for chunk_i in 0..4 {
-        let chunk_start = chunk_i * 64;
-        let q_start = chunk_i * 32;
+        for chunk_i in 0..4 {
+            let chunk_start = chunk_i * 64;
+            let q_start = chunk_i * 32;
 
-        let d1 = d * f32::from(scales[chunk_i * 2]);
-        let dm1 = dmin * f32::from(mins[chunk_i * 2]);
-        let d2 = d * f32::from(scales[chunk_i * 2 + 1]);
-        let dm2 = dmin * f32::from(mins[chunk_i * 2 + 1]);
+            let d1 = d * f32::from(scales[chunk_i * 2]);
+            let dm1 = dmin * f32::from(mins[chunk_i * 2]);
+            let d2 = d * f32::from(scales[chunk_i * 2 + 1]);
+            let dm2 = dmin * f32::from(mins[chunk_i * 2 + 1]);
 
-        let d1_vec = _mm256_set1_ps(d1);
-        let dm1_vec = _mm256_set1_ps(dm1);
-        let d2_vec = _mm256_set1_ps(d2);
-        let dm2_vec = _mm256_set1_ps(dm2);
+            let d1_vec = _mm256_set1_ps(d1);
+            let dm1_vec = _mm256_set1_ps(dm1);
+            let d2_vec = _mm256_set1_ps(d2);
+            let dm2_vec = _mm256_set1_ps(dm2);
 
-        // Process low nibbles (32 values) in groups of 8
-        let mut i = 0;
-        while i + 8 <= 32 {
-            let input_base = input_offset + chunk_start + i;
-            if input_base + 8 <= in_dim {
-                let q_bytes = _mm_loadl_epi64(qs.as_ptr().add(q_start + i) as *const __m128i);
-                let q_i32 = _mm256_cvtepu8_epi32(q_bytes);
-                let q_low = _mm256_and_si256(q_i32, low_mask);
-                let q_f32 = _mm256_cvtepi32_ps(q_low);
-                let x = _mm256_loadu_ps(input.as_ptr().add(input_base));
-                let dequant = _mm256_fmsub_ps(d1_vec, q_f32, dm1_vec);
-                *acc = _mm256_fmadd_ps(dequant, x, *acc);
+            // Process low nibbles (32 values) in groups of 8
+            let mut i = 0;
+            while i + 8 <= 32 {
+                let input_base = input_offset + chunk_start + i;
+                if input_base + 8 <= in_dim {
+                    let q_bytes = _mm_loadl_epi64(qs.as_ptr().add(q_start + i) as *const __m128i);
+                    let q_i32 = _mm256_cvtepu8_epi32(q_bytes);
+                    let q_low = _mm256_and_si256(q_i32, low_mask);
+                    let q_f32 = _mm256_cvtepi32_ps(q_low);
+                    let x = _mm256_loadu_ps(input.as_ptr().add(input_base));
+                    let dequant = _mm256_fmsub_ps(d1_vec, q_f32, dm1_vec);
+                    *acc = _mm256_fmadd_ps(dequant, x, *acc);
+                }
+                i += 8;
             }
-            i += 8;
-        }
 
-        // Process high nibbles (32 values) in groups of 8
-        let mut i = 0;
-        while i + 8 <= 32 {
-            let input_base = input_offset + chunk_start + 32 + i;
-            if input_base + 8 <= in_dim {
-                let q_bytes = _mm_loadl_epi64(qs.as_ptr().add(q_start + i) as *const __m128i);
-                let q_i32 = _mm256_cvtepu8_epi32(q_bytes);
-                let q_high = _mm256_srli_epi32(q_i32, 4);
-                let q_f32 = _mm256_cvtepi32_ps(q_high);
-                let x = _mm256_loadu_ps(input.as_ptr().add(input_base));
-                let dequant = _mm256_fmsub_ps(d2_vec, q_f32, dm2_vec);
-                *acc = _mm256_fmadd_ps(dequant, x, *acc);
+            // Process high nibbles (32 values) in groups of 8
+            let mut i = 0;
+            while i + 8 <= 32 {
+                let input_base = input_offset + chunk_start + 32 + i;
+                if input_base + 8 <= in_dim {
+                    let q_bytes = _mm_loadl_epi64(qs.as_ptr().add(q_start + i) as *const __m128i);
+                    let q_i32 = _mm256_cvtepu8_epi32(q_bytes);
+                    let q_high = _mm256_srli_epi32(q_i32, 4);
+                    let q_f32 = _mm256_cvtepi32_ps(q_high);
+                    let x = _mm256_loadu_ps(input.as_ptr().add(input_base));
+                    let dequant = _mm256_fmsub_ps(d2_vec, q_f32, dm2_vec);
+                    *acc = _mm256_fmadd_ps(dequant, x, *acc);
+                }
+                i += 8;
             }
-            i += 8;
         }
     }
-}}
+}
 
 /// AVX2 horizontal sum of 8 f32 lanes to a single f32.
 #[cfg(target_arch = "x86_64")]
@@ -136,30 +147,39 @@ pub(crate) unsafe fn compute_chunk_q4k_avx2(
     in_dim: usize,
     num_blocks_per_row: usize,
     row_bytes: usize,
-) { unsafe {
-    use std::arch::x86_64::*;
+) {
+    unsafe {
+        use std::arch::x86_64::*;
 
-    let low_mask = _mm256_set1_epi32(0x0F);
+        let low_mask = _mm256_set1_epi32(0x0F);
 
-    for (local_idx, out_val) in chunk.iter_mut().enumerate() {
-        let out_idx = start_row + local_idx;
-        if out_idx >= out_dim {
-            break;
-        }
-
-        let row_start = out_idx * row_bytes;
-        let mut acc = _mm256_setzero_ps();
-
-        for sb_idx in 0..num_blocks_per_row {
-            let sb_start = row_start + sb_idx * SUPER_BLOCK_BYTES;
-            if sb_start + SUPER_BLOCK_BYTES > q4k_data.len() {
+        for (local_idx, out_val) in chunk.iter_mut().enumerate() {
+            let out_idx = start_row + local_idx;
+            if out_idx >= out_dim {
                 break;
             }
-            let sb_data = &q4k_data[sb_start..sb_start + SUPER_BLOCK_BYTES];
-            let input_offset = sb_idx * SUPER_BLOCK_SIZE;
-            process_q4k_superblock_avx2(sb_data, input, input_offset, in_dim, low_mask, &mut acc);
-        }
 
-        *out_val = hsum_avx2(acc);
+            let row_start = out_idx * row_bytes;
+            let mut acc = _mm256_setzero_ps();
+
+            for sb_idx in 0..num_blocks_per_row {
+                let sb_start = row_start + sb_idx * SUPER_BLOCK_BYTES;
+                if sb_start + SUPER_BLOCK_BYTES > q4k_data.len() {
+                    break;
+                }
+                let sb_data = &q4k_data[sb_start..sb_start + SUPER_BLOCK_BYTES];
+                let input_offset = sb_idx * SUPER_BLOCK_SIZE;
+                process_q4k_superblock_avx2(
+                    sb_data,
+                    input,
+                    input_offset,
+                    in_dim,
+                    low_mask,
+                    &mut acc,
+                );
+            }
+
+            *out_val = hsum_avx2(acc);
+        }
     }
-}}
+}

--- a/src/backends/q6k/gemv.rs
+++ b/src/backends/q6k/gemv.rs
@@ -123,37 +123,39 @@ unsafe fn process_q6k_superblock_avx2(
     input_offset: usize,
     in_dim: usize,
     acc: &mut std::arch::x86_64::__m256,
-) { unsafe {
-    use std::arch::x86_64::*;
+) {
+    unsafe {
+        use std::arch::x86_64::*;
 
-    let ql = sb_data.get(0..128).expect("Q6_K: need ≥128 bytes for ql");
-    let qh = sb_data.get(128..192).expect("Q6_K: need ≥192 bytes for qh");
-    let scales = sb_data.get(192..208).expect("Q6_K: need ≥208 bytes for scales");
-    let d = f16_to_f32(u16::from_le_bytes([sb_data[208], sb_data[209]]));
-    let d_vec = _mm256_set1_ps(d);
+        let ql = sb_data.get(0..128).expect("Q6_K: need ≥128 bytes for ql");
+        let qh = sb_data.get(128..192).expect("Q6_K: need ≥192 bytes for qh");
+        let scales = sb_data.get(192..208).expect("Q6_K: need ≥208 bytes for scales");
+        let d = f16_to_f32(u16::from_le_bytes([sb_data[208], sb_data[209]]));
+        let d_vec = _mm256_set1_ps(d);
 
-    for group in 0..16 {
-        let scale = (scales[group] as i8) as f32;
-        let ds_vec = _mm256_mul_ps(d_vec, _mm256_set1_ps(scale));
-        let group_offset = group * 16;
-        let input_group = input_offset + group_offset;
+        for group in 0..16 {
+            let scale = (scales[group] as i8) as f32;
+            let ds_vec = _mm256_mul_ps(d_vec, _mm256_set1_ps(scale));
+            let group_offset = group * 16;
+            let input_group = input_offset + group_offset;
 
-        for half in 0..2 {
-            let half_offset = half * 8;
-            let input_base = input_group + half_offset;
-            if input_base + 8 > in_dim {
-                continue;
+            for half in 0..2 {
+                let half_offset = half * 8;
+                let input_base = input_group + half_offset;
+                if input_base + 8 > in_dim {
+                    continue;
+                }
+
+                let q6_vals = extract_q6k_values(ql, qh, group_offset + half_offset);
+                let q6_i32 = _mm256_loadu_si256(q6_vals.as_ptr() as *const __m256i);
+                let q6_f32 = _mm256_cvtepi32_ps(q6_i32);
+                let x = _mm256_loadu_ps(input.as_ptr().add(input_base));
+                let dequant = _mm256_mul_ps(ds_vec, q6_f32);
+                *acc = _mm256_fmadd_ps(dequant, x, *acc);
             }
-
-            let q6_vals = extract_q6k_values(ql, qh, group_offset + half_offset);
-            let q6_i32 = _mm256_loadu_si256(q6_vals.as_ptr() as *const __m256i);
-            let q6_f32 = _mm256_cvtepi32_ps(q6_i32);
-            let x = _mm256_loadu_ps(input.as_ptr().add(input_base));
-            let dequant = _mm256_mul_ps(ds_vec, q6_f32);
-            *acc = _mm256_fmadd_ps(dequant, x, *acc);
         }
     }
-}}
+}
 
 /// Fused Q6_K matrix-vector multiply with AVX2 SIMD
 ///
@@ -167,33 +169,35 @@ unsafe fn matmul_q6k_f32_avx2(
     input: &[f32],
     out_dim: usize,
     in_dim: usize,
-) -> Vec<f32> { unsafe {
-    use std::arch::x86_64::*;
+) -> Vec<f32> {
+    unsafe {
+        use std::arch::x86_64::*;
 
-    let num_blocks_per_row = (in_dim + SUPER_BLOCK_SIZE - 1) / SUPER_BLOCK_SIZE;
-    let row_bytes = num_blocks_per_row * SUPER_BLOCK_BYTES;
+        let num_blocks_per_row = (in_dim + SUPER_BLOCK_SIZE - 1) / SUPER_BLOCK_SIZE;
+        let row_bytes = num_blocks_per_row * SUPER_BLOCK_BYTES;
 
-    let mut output = vec![0.0f32; out_dim];
+        let mut output = vec![0.0f32; out_dim];
 
-    for out_idx in 0..out_dim {
-        let row_start = out_idx * row_bytes;
-        let mut acc = _mm256_setzero_ps();
+        for out_idx in 0..out_dim {
+            let row_start = out_idx * row_bytes;
+            let mut acc = _mm256_setzero_ps();
 
-        for sb_idx in 0..num_blocks_per_row {
-            let sb_start = row_start + sb_idx * SUPER_BLOCK_BYTES;
-            if sb_start + SUPER_BLOCK_BYTES > q6k_data.len() {
-                break;
+            for sb_idx in 0..num_blocks_per_row {
+                let sb_start = row_start + sb_idx * SUPER_BLOCK_BYTES;
+                if sb_start + SUPER_BLOCK_BYTES > q6k_data.len() {
+                    break;
+                }
+                let sb_data = &q6k_data[sb_start..sb_start + SUPER_BLOCK_BYTES];
+                let input_offset = sb_idx * SUPER_BLOCK_SIZE;
+                process_q6k_superblock_avx2(sb_data, input, input_offset, in_dim, &mut acc);
             }
-            let sb_data = &q6k_data[sb_start..sb_start + SUPER_BLOCK_BYTES];
-            let input_offset = sb_idx * SUPER_BLOCK_SIZE;
-            process_q6k_superblock_avx2(sb_data, input, input_offset, in_dim, &mut acc);
+
+            output[out_idx] = hsum_q6k_avx2(acc);
         }
 
-        output[out_idx] = hsum_q6k_avx2(acc);
+        output
     }
-
-    output
-}}
+}
 
 /// Runtime dispatch for Q6K matmul - uses AVX2 if available
 ///
@@ -331,31 +335,33 @@ unsafe fn compute_chunk_avx2(
     in_dim: usize,
     num_blocks_per_row: usize,
     row_bytes: usize,
-) { unsafe {
-    use std::arch::x86_64::*;
+) {
+    unsafe {
+        use std::arch::x86_64::*;
 
-    for (local_idx, out_val) in chunk.iter_mut().enumerate() {
-        let out_idx = start_row + local_idx;
-        if out_idx >= out_dim {
-            break;
-        }
-
-        let row_start = out_idx * row_bytes;
-        let mut acc = _mm256_setzero_ps();
-
-        for sb_idx in 0..num_blocks_per_row {
-            let sb_start = row_start + sb_idx * SUPER_BLOCK_BYTES;
-            if sb_start + SUPER_BLOCK_BYTES > q6k_data.len() {
+        for (local_idx, out_val) in chunk.iter_mut().enumerate() {
+            let out_idx = start_row + local_idx;
+            if out_idx >= out_dim {
                 break;
             }
-            let sb_data = &q6k_data[sb_start..sb_start + SUPER_BLOCK_BYTES];
-            let input_offset = sb_idx * SUPER_BLOCK_SIZE;
-            process_q6k_superblock_avx2(sb_data, input, input_offset, in_dim, &mut acc);
-        }
 
-        *out_val = hsum_q6k_avx2(acc);
+            let row_start = out_idx * row_bytes;
+            let mut acc = _mm256_setzero_ps();
+
+            for sb_idx in 0..num_blocks_per_row {
+                let sb_start = row_start + sb_idx * SUPER_BLOCK_BYTES;
+                if sb_start + SUPER_BLOCK_BYTES > q6k_data.len() {
+                    break;
+                }
+                let sb_data = &q6k_data[sb_start..sb_start + SUPER_BLOCK_BYTES];
+                let input_offset = sb_idx * SUPER_BLOCK_SIZE;
+                process_q6k_superblock_avx2(sb_data, input, input_offset, in_dim, &mut acc);
+            }
+
+            *out_val = hsum_q6k_avx2(acc);
+        }
     }
-}}
+}
 
 pub(crate) fn compute_chunk_scalar(
     q6k_data: &[u8],

--- a/src/backends/sse2/mod.rs
+++ b/src/backends/sse2/mod.rs
@@ -23,231 +23,285 @@ impl VectorBackend for Sse2Backend {
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::add(a, b, result);
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::sub(a, b, result);
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::mul(a, b, result);
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-        ops::arithmetic::div(a, b, result);
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn dot(a: &[f32], b: &[f32]) -> f32 { unsafe {
-        ops::reductions::dot(a, b)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sum(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::sum(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn max(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::max(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn min(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::min(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn argmax(a: &[f32]) -> usize { unsafe {
-        ops::reductions::argmax(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn argmin(a: &[f32]) -> usize { unsafe {
-        ops::reductions::argmin(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sum_kahan(a: &[f32]) -> f32 { unsafe {
-        ops::reductions::sum_kahan(a)
-    }}
-
-    #[inline]
-    #[target_feature(enable = "sse2")]
-    // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn norm_l2(a: &[f32]) -> f32 { unsafe {
-        if a.is_empty() {
-            return 0.0;
+    unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::arithmetic::add(a, b, result);
         }
-        Self::dot(a, a).sqrt()
-    }}
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn norm_l1(a: &[f32]) -> f32 { unsafe {
-        ops::elementwise::norm_l1(a)
-    }}
+    unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::arithmetic::sub(a, b, result);
+        }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn norm_linf(a: &[f32]) -> f32 { unsafe {
-        ops::elementwise::norm_linf(a)
-    }}
+    unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::arithmetic::mul(a, b, result);
+        }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn scale(a: &[f32], scalar: f32, result: &mut [f32]) { unsafe {
-        ops::elementwise::scale(a, scalar, result);
-    }}
+    unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::arithmetic::div(a, b, result);
+        }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn abs(a: &[f32], result: &mut [f32]) { unsafe {
-        ops::elementwise::abs(a, result);
-    }}
+    unsafe fn dot(a: &[f32], b: &[f32]) -> f32 {
+        unsafe { ops::reductions::dot(a, b) }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn clamp(a: &[f32], min_val: f32, max_val: f32, result: &mut [f32]) { unsafe {
-        ops::elementwise::clamp(a, min_val, max_val, result);
-    }}
+    unsafe fn sum(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::sum(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn lerp(a: &[f32], b: &[f32], t: f32, result: &mut [f32]) { unsafe {
-        ops::elementwise::lerp(a, b, t, result);
-    }}
+    unsafe fn max(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::max(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn fma(a: &[f32], b: &[f32], c: &[f32], result: &mut [f32]) { unsafe {
-        ops::elementwise::fma(a, b, c, result);
-    }}
+    unsafe fn min(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::min(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn relu(a: &[f32], result: &mut [f32]) { unsafe {
-        ops::elementwise::relu(a, result);
-    }}
+    unsafe fn argmax(a: &[f32]) -> usize {
+        unsafe { ops::reductions::argmax(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn exp(a: &[f32], result: &mut [f32]) { unsafe {
-        ops::activations::exp(a, result);
-    }}
+    unsafe fn argmin(a: &[f32]) -> usize {
+        unsafe { ops::reductions::argmin(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sigmoid(a: &[f32], result: &mut [f32]) { unsafe {
-        ops::activations::sigmoid(a, result);
-    }}
+    unsafe fn sum_kahan(a: &[f32]) -> f32 {
+        unsafe { ops::reductions::sum_kahan(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn gelu(a: &[f32], result: &mut [f32]) { unsafe {
-        ops::activations::gelu(a, result);
-    }}
+    unsafe fn norm_l2(a: &[f32]) -> f32 {
+        unsafe {
+            if a.is_empty() {
+                return 0.0;
+            }
+            Self::dot(a, a).sqrt()
+        }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn swish(a: &[f32], result: &mut [f32]) { unsafe {
-        ops::activations::swish(a, result);
-    }}
+    unsafe fn norm_l1(a: &[f32]) -> f32 {
+        unsafe { ops::elementwise::norm_l1(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn tanh(a: &[f32], result: &mut [f32]) { unsafe {
-        ops::activations::tanh(a, result);
-    }}
+    unsafe fn norm_linf(a: &[f32]) -> f32 {
+        unsafe { ops::elementwise::norm_linf(a) }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sqrt(a: &[f32], result: &mut [f32]) { unsafe {
-        ops::elementwise::sqrt(a, result);
-    }}
+    unsafe fn scale(a: &[f32], scalar: f32, result: &mut [f32]) {
+        unsafe {
+            ops::elementwise::scale(a, scalar, result);
+        }
+    }
 
     #[inline]
     #[target_feature(enable = "sse2")]
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn recip(a: &[f32], result: &mut [f32]) { unsafe {
-        ops::elementwise::recip(a, result);
-    }}
+    unsafe fn abs(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::elementwise::abs(a, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn clamp(a: &[f32], min_val: f32, max_val: f32, result: &mut [f32]) {
+        unsafe {
+            ops::elementwise::clamp(a, min_val, max_val, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn lerp(a: &[f32], b: &[f32], t: f32, result: &mut [f32]) {
+        unsafe {
+            ops::elementwise::lerp(a, b, t, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn fma(a: &[f32], b: &[f32], c: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::elementwise::fma(a, b, c, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn relu(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::elementwise::relu(a, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn exp(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::activations::exp(a, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn sigmoid(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::activations::sigmoid(a, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn gelu(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::activations::gelu(a, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn swish(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::activations::swish(a, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn tanh(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::activations::tanh(a, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn sqrt(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::elementwise::sqrt(a, result);
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    // SAFETY: caller ensures preconditions are met for this unsafe function
+    unsafe fn recip(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            ops::elementwise::recip(a, result);
+        }
+    }
 
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn ln(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::ln(a, result);
-    }}
+    unsafe fn ln(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::ln(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn log2(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::log2(a, result);
-    }}
+    unsafe fn log2(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::log2(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn log10(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::log10(a, result);
-    }}
+    unsafe fn log10(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::log10(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn sin(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::sin(a, result);
-    }}
+    unsafe fn sin(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::sin(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn cos(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::cos(a, result);
-    }}
+    unsafe fn cos(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::cos(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn tan(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::tan(a, result);
-    }}
+    unsafe fn tan(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::tan(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn floor(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::floor(a, result);
-    }}
+    unsafe fn floor(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::floor(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn ceil(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::ceil(a, result);
-    }}
+    unsafe fn ceil(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::ceil(a, result);
+        }
+    }
     // SAFETY: caller ensures preconditions are met for this unsafe function
-    unsafe fn round(a: &[f32], result: &mut [f32]) { unsafe {
-        super::scalar::ScalarBackend::round(a, result);
-    }}
+    unsafe fn round(a: &[f32], result: &mut [f32]) {
+        unsafe {
+            super::scalar::ScalarBackend::round(a, result);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/backends/sse2/ops/activations.rs
+++ b/src/backends/sse2/ops/activations.rs
@@ -35,165 +35,176 @@ pub(crate) unsafe fn exp_approx_sse2(x: __m128) -> __m128 {
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn exp(a: &[f32], result: &mut [f32]) { unsafe {
-    // Polynomial approximation for exp - range reduction + polynomial
-    let len = a.len();
-    let mut i = 0;
-    let ln2 = _mm_set1_ps(std::f32::consts::LN_2);
-    let inv_ln2 = _mm_set1_ps(1.0 / std::f32::consts::LN_2);
-    let c1 = _mm_set1_ps(1.0);
-    let c2 = _mm_set1_ps(0.5);
-    let c3 = _mm_set1_ps(0.166_666_67);
-    let c4 = _mm_set1_ps(0.041_666_668);
-    let c5 = _mm_set1_ps(0.008_333_334);
-    while i + 4 <= len {
-        let x = _mm_loadu_ps(a.as_ptr().add(i));
-        let k = _mm_cvtps_epi32(_mm_mul_ps(x, inv_ln2));
-        let kf = _mm_cvtepi32_ps(k);
-        let r = _mm_sub_ps(x, _mm_mul_ps(kf, ln2));
-        let mut poly = _mm_add_ps(c1, _mm_mul_ps(r, c5));
-        poly = _mm_add_ps(c1, _mm_mul_ps(r, _mm_add_ps(c4, _mm_mul_ps(r, poly))));
-        poly = _mm_add_ps(c1, _mm_mul_ps(r, _mm_add_ps(c3, _mm_mul_ps(r, poly))));
-        poly = _mm_add_ps(c1, _mm_mul_ps(r, _mm_add_ps(c2, _mm_mul_ps(r, poly))));
-        poly = _mm_add_ps(c1, _mm_mul_ps(r, poly));
-        let exp_k = _mm_castsi128_ps(_mm_slli_epi32(_mm_add_epi32(k, _mm_set1_epi32(127)), 23));
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_mul_ps(poly, exp_k));
-        i += 4;
+pub(crate) unsafe fn exp(a: &[f32], result: &mut [f32]) {
+    unsafe {
+        // Polynomial approximation for exp - range reduction + polynomial
+        let len = a.len();
+        let mut i = 0;
+        let ln2 = _mm_set1_ps(std::f32::consts::LN_2);
+        let inv_ln2 = _mm_set1_ps(1.0 / std::f32::consts::LN_2);
+        let c1 = _mm_set1_ps(1.0);
+        let c2 = _mm_set1_ps(0.5);
+        let c3 = _mm_set1_ps(0.166_666_67);
+        let c4 = _mm_set1_ps(0.041_666_668);
+        let c5 = _mm_set1_ps(0.008_333_334);
+        while i + 4 <= len {
+            let x = _mm_loadu_ps(a.as_ptr().add(i));
+            let k = _mm_cvtps_epi32(_mm_mul_ps(x, inv_ln2));
+            let kf = _mm_cvtepi32_ps(k);
+            let r = _mm_sub_ps(x, _mm_mul_ps(kf, ln2));
+            let mut poly = _mm_add_ps(c1, _mm_mul_ps(r, c5));
+            poly = _mm_add_ps(c1, _mm_mul_ps(r, _mm_add_ps(c4, _mm_mul_ps(r, poly))));
+            poly = _mm_add_ps(c1, _mm_mul_ps(r, _mm_add_ps(c3, _mm_mul_ps(r, poly))));
+            poly = _mm_add_ps(c1, _mm_mul_ps(r, _mm_add_ps(c2, _mm_mul_ps(r, poly))));
+            poly = _mm_add_ps(c1, _mm_mul_ps(r, poly));
+            let exp_k = _mm_castsi128_ps(_mm_slli_epi32(_mm_add_epi32(k, _mm_set1_epi32(127)), 23));
+            _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_mul_ps(poly, exp_k));
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j].exp();
+        }
     }
-    for j in i..len {
-        result[j] = a[j].exp();
-    }
-}}
+}
 
 /// SSE2 sigmoid activation.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn sigmoid(a: &[f32], result: &mut [f32]) { unsafe {
-    // sigmoid(x) = 1 / (1 + exp(-x))
-    let len = a.len();
-    let mut i = 0;
-    let one = _mm_set1_ps(1.0);
-    let neg_one = _mm_set1_ps(-1.0);
-    let ln2 = _mm_set1_ps(std::f32::consts::LN_2);
-    let inv_ln2 = _mm_set1_ps(1.0 / std::f32::consts::LN_2);
-    let c2 = _mm_set1_ps(0.5);
-    let c3 = _mm_set1_ps(0.166_666_67);
-    let c4 = _mm_set1_ps(0.041_666_668);
-    let c5 = _mm_set1_ps(0.008_333_334);
-    while i + 4 <= len {
-        let x = _mm_loadu_ps(a.as_ptr().add(i));
-        let neg_x = _mm_mul_ps(x, neg_one);
-        let k = _mm_cvtps_epi32(_mm_mul_ps(neg_x, inv_ln2));
-        let kf = _mm_cvtepi32_ps(k);
-        let r = _mm_sub_ps(neg_x, _mm_mul_ps(kf, ln2));
-        let mut poly = _mm_add_ps(one, _mm_mul_ps(r, c5));
-        poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c4, _mm_mul_ps(r, poly))));
-        poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c3, _mm_mul_ps(r, poly))));
-        poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c2, _mm_mul_ps(r, poly))));
-        poly = _mm_add_ps(one, _mm_mul_ps(r, poly));
-        let exp_k = _mm_castsi128_ps(_mm_slli_epi32(_mm_add_epi32(k, _mm_set1_epi32(127)), 23));
-        let exp_neg_x = _mm_mul_ps(poly, exp_k);
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_div_ps(one, _mm_add_ps(one, exp_neg_x)));
-        i += 4;
+pub(crate) unsafe fn sigmoid(a: &[f32], result: &mut [f32]) {
+    unsafe {
+        // sigmoid(x) = 1 / (1 + exp(-x))
+        let len = a.len();
+        let mut i = 0;
+        let one = _mm_set1_ps(1.0);
+        let neg_one = _mm_set1_ps(-1.0);
+        let ln2 = _mm_set1_ps(std::f32::consts::LN_2);
+        let inv_ln2 = _mm_set1_ps(1.0 / std::f32::consts::LN_2);
+        let c2 = _mm_set1_ps(0.5);
+        let c3 = _mm_set1_ps(0.166_666_67);
+        let c4 = _mm_set1_ps(0.041_666_668);
+        let c5 = _mm_set1_ps(0.008_333_334);
+        while i + 4 <= len {
+            let x = _mm_loadu_ps(a.as_ptr().add(i));
+            let neg_x = _mm_mul_ps(x, neg_one);
+            let k = _mm_cvtps_epi32(_mm_mul_ps(neg_x, inv_ln2));
+            let kf = _mm_cvtepi32_ps(k);
+            let r = _mm_sub_ps(neg_x, _mm_mul_ps(kf, ln2));
+            let mut poly = _mm_add_ps(one, _mm_mul_ps(r, c5));
+            poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c4, _mm_mul_ps(r, poly))));
+            poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c3, _mm_mul_ps(r, poly))));
+            poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c2, _mm_mul_ps(r, poly))));
+            poly = _mm_add_ps(one, _mm_mul_ps(r, poly));
+            let exp_k = _mm_castsi128_ps(_mm_slli_epi32(_mm_add_epi32(k, _mm_set1_epi32(127)), 23));
+            let exp_neg_x = _mm_mul_ps(poly, exp_k);
+            _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_div_ps(one, _mm_add_ps(one, exp_neg_x)));
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = 1.0 / (1.0 + (-a[j]).exp());
+        }
     }
-    for j in i..len {
-        result[j] = 1.0 / (1.0 + (-a[j]).exp());
-    }
-}}
+}
 
 /// SSE2 GELU activation.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn gelu(a: &[f32], result: &mut [f32]) { unsafe {
-    // GELU(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
-    let len = a.len();
-    let mut i = 0;
-    let half = _mm_set1_ps(0.5);
-    let one = _mm_set1_ps(1.0);
-    let sqrt_2_pi = _mm_set1_ps(0.797_884_56);
-    let coeff = _mm_set1_ps(0.044_715);
-    while i + 4 <= len {
-        let x = _mm_loadu_ps(a.as_ptr().add(i));
-        let x3 = _mm_mul_ps(_mm_mul_ps(x, x), x);
-        let inner = _mm_mul_ps(sqrt_2_pi, _mm_add_ps(x, _mm_mul_ps(coeff, x3)));
-        // tanh approximation: (e^2x - 1) / (e^2x + 1)
-        let two_inner = _mm_add_ps(inner, inner);
-        let exp_2x = exp_approx_sse2(two_inner);
-        let tanh_val = _mm_div_ps(_mm_sub_ps(exp_2x, one), _mm_add_ps(exp_2x, one));
-        _mm_storeu_ps(
-            result.as_mut_ptr().add(i),
-            _mm_mul_ps(half, _mm_mul_ps(x, _mm_add_ps(one, tanh_val))),
-        );
-        i += 4;
+pub(crate) unsafe fn gelu(a: &[f32], result: &mut [f32]) {
+    unsafe {
+        // GELU(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+        let len = a.len();
+        let mut i = 0;
+        let half = _mm_set1_ps(0.5);
+        let one = _mm_set1_ps(1.0);
+        let sqrt_2_pi = _mm_set1_ps(0.797_884_56);
+        let coeff = _mm_set1_ps(0.044_715);
+        while i + 4 <= len {
+            let x = _mm_loadu_ps(a.as_ptr().add(i));
+            let x3 = _mm_mul_ps(_mm_mul_ps(x, x), x);
+            let inner = _mm_mul_ps(sqrt_2_pi, _mm_add_ps(x, _mm_mul_ps(coeff, x3)));
+            // tanh approximation: (e^2x - 1) / (e^2x + 1)
+            let two_inner = _mm_add_ps(inner, inner);
+            let exp_2x = exp_approx_sse2(two_inner);
+            let tanh_val = _mm_div_ps(_mm_sub_ps(exp_2x, one), _mm_add_ps(exp_2x, one));
+            _mm_storeu_ps(
+                result.as_mut_ptr().add(i),
+                _mm_mul_ps(half, _mm_mul_ps(x, _mm_add_ps(one, tanh_val))),
+            );
+            i += 4;
+        }
+        for j in i..len {
+            let x = a[j];
+            result[j] = 0.5
+                * x
+                * (1.0 + ((0.797_884_56 * (x + 0.044_715 * x * x * x)) as f64).tanh() as f32);
+        }
     }
-    for j in i..len {
-        let x = a[j];
-        result[j] =
-            0.5 * x * (1.0 + ((0.797_884_56 * (x + 0.044_715 * x * x * x)) as f64).tanh() as f32);
-    }
-}}
+}
 
 /// SSE2 swish activation.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn swish(a: &[f32], result: &mut [f32]) { unsafe {
-    // swish(x) = x * sigmoid(x)
-    let len = a.len();
-    let mut i = 0;
-    let one = _mm_set1_ps(1.0);
-    let neg_one = _mm_set1_ps(-1.0);
-    let ln2 = _mm_set1_ps(std::f32::consts::LN_2);
-    let inv_ln2 = _mm_set1_ps(1.0 / std::f32::consts::LN_2);
-    let c2 = _mm_set1_ps(0.5);
-    let c3 = _mm_set1_ps(0.166_666_67);
-    let c4 = _mm_set1_ps(0.041_666_668);
-    let c5 = _mm_set1_ps(0.008_333_334);
-    while i + 4 <= len {
-        let x = _mm_loadu_ps(a.as_ptr().add(i));
-        let neg_x = _mm_mul_ps(x, neg_one);
-        let k = _mm_cvtps_epi32(_mm_mul_ps(neg_x, inv_ln2));
-        let kf = _mm_cvtepi32_ps(k);
-        let r = _mm_sub_ps(neg_x, _mm_mul_ps(kf, ln2));
-        let mut poly = _mm_add_ps(one, _mm_mul_ps(r, c5));
-        poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c4, _mm_mul_ps(r, poly))));
-        poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c3, _mm_mul_ps(r, poly))));
-        poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c2, _mm_mul_ps(r, poly))));
-        poly = _mm_add_ps(one, _mm_mul_ps(r, poly));
-        let exp_k = _mm_castsi128_ps(_mm_slli_epi32(_mm_add_epi32(k, _mm_set1_epi32(127)), 23));
-        let exp_neg_x = _mm_mul_ps(poly, exp_k);
-        let sigmoid = _mm_div_ps(one, _mm_add_ps(one, exp_neg_x));
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_mul_ps(x, sigmoid));
-        i += 4;
+pub(crate) unsafe fn swish(a: &[f32], result: &mut [f32]) {
+    unsafe {
+        // swish(x) = x * sigmoid(x)
+        let len = a.len();
+        let mut i = 0;
+        let one = _mm_set1_ps(1.0);
+        let neg_one = _mm_set1_ps(-1.0);
+        let ln2 = _mm_set1_ps(std::f32::consts::LN_2);
+        let inv_ln2 = _mm_set1_ps(1.0 / std::f32::consts::LN_2);
+        let c2 = _mm_set1_ps(0.5);
+        let c3 = _mm_set1_ps(0.166_666_67);
+        let c4 = _mm_set1_ps(0.041_666_668);
+        let c5 = _mm_set1_ps(0.008_333_334);
+        while i + 4 <= len {
+            let x = _mm_loadu_ps(a.as_ptr().add(i));
+            let neg_x = _mm_mul_ps(x, neg_one);
+            let k = _mm_cvtps_epi32(_mm_mul_ps(neg_x, inv_ln2));
+            let kf = _mm_cvtepi32_ps(k);
+            let r = _mm_sub_ps(neg_x, _mm_mul_ps(kf, ln2));
+            let mut poly = _mm_add_ps(one, _mm_mul_ps(r, c5));
+            poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c4, _mm_mul_ps(r, poly))));
+            poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c3, _mm_mul_ps(r, poly))));
+            poly = _mm_add_ps(one, _mm_mul_ps(r, _mm_add_ps(c2, _mm_mul_ps(r, poly))));
+            poly = _mm_add_ps(one, _mm_mul_ps(r, poly));
+            let exp_k = _mm_castsi128_ps(_mm_slli_epi32(_mm_add_epi32(k, _mm_set1_epi32(127)), 23));
+            let exp_neg_x = _mm_mul_ps(poly, exp_k);
+            let sigmoid = _mm_div_ps(one, _mm_add_ps(one, exp_neg_x));
+            _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_mul_ps(x, sigmoid));
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j] / (1.0 + (-a[j]).exp());
+        }
     }
-    for j in i..len {
-        result[j] = a[j] / (1.0 + (-a[j]).exp());
-    }
-}}
+}
 
 /// SSE2 tanh activation.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn tanh(a: &[f32], result: &mut [f32]) { unsafe {
-    // tanh(x) = (e^2x - 1) / (e^2x + 1)
-    let len = a.len();
-    let mut i = 0;
-    let one = _mm_set1_ps(1.0);
-    let two = _mm_set1_ps(2.0);
-    while i + 4 <= len {
-        let x = _mm_loadu_ps(a.as_ptr().add(i));
-        let exp_2x = exp_approx_sse2(_mm_mul_ps(two, x));
-        _mm_storeu_ps(
-            result.as_mut_ptr().add(i),
-            _mm_div_ps(_mm_sub_ps(exp_2x, one), _mm_add_ps(exp_2x, one)),
-        );
-        i += 4;
+pub(crate) unsafe fn tanh(a: &[f32], result: &mut [f32]) {
+    unsafe {
+        // tanh(x) = (e^2x - 1) / (e^2x + 1)
+        let len = a.len();
+        let mut i = 0;
+        let one = _mm_set1_ps(1.0);
+        let two = _mm_set1_ps(2.0);
+        while i + 4 <= len {
+            let x = _mm_loadu_ps(a.as_ptr().add(i));
+            let exp_2x = exp_approx_sse2(_mm_mul_ps(two, x));
+            _mm_storeu_ps(
+                result.as_mut_ptr().add(i),
+                _mm_div_ps(_mm_sub_ps(exp_2x, one), _mm_add_ps(exp_2x, one)),
+            );
+            i += 4;
+        }
+        for j in i..len {
+            let exp_2x = (2.0 * a[j]).exp();
+            result[j] = (exp_2x - 1.0) / (exp_2x + 1.0);
+        }
     }
-    for j in i..len {
-        let exp_2x = (2.0 * a[j]).exp();
-        result[j] = (exp_2x - 1.0) / (exp_2x + 1.0);
-    }
-}}
+}

--- a/src/backends/sse2/ops/arithmetic.rs
+++ b/src/backends/sse2/ops/arithmetic.rs
@@ -7,70 +7,78 @@ use std::arch::x86_64::*;
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    while i + 4 <= len {
-        let va = _mm_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm_loadu_ps(b.as_ptr().add(i));
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_add_ps(va, vb));
-        i += 4;
+pub(crate) unsafe fn add(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        while i + 4 <= len {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_add_ps(va, vb));
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j] + b[j];
+        }
     }
-    for j in i..len {
-        result[j] = a[j] + b[j];
-    }
-}}
+}
 
 /// SSE2 vector subtraction.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    while i + 4 <= len {
-        let va = _mm_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm_loadu_ps(b.as_ptr().add(i));
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_sub_ps(va, vb));
-        i += 4;
+pub(crate) unsafe fn sub(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        while i + 4 <= len {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_sub_ps(va, vb));
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j] - b[j];
+        }
     }
-    for j in i..len {
-        result[j] = a[j] - b[j];
-    }
-}}
+}
 
 /// SSE2 vector multiplication.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    while i + 4 <= len {
-        let va = _mm_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm_loadu_ps(b.as_ptr().add(i));
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_mul_ps(va, vb));
-        i += 4;
+pub(crate) unsafe fn mul(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        while i + 4 <= len {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_mul_ps(va, vb));
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j] * b[j];
+        }
     }
-    for j in i..len {
-        result[j] = a[j] * b[j];
-    }
-}}
+}
 
 /// SSE2 vector division.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    while i + 4 <= len {
-        let va = _mm_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm_loadu_ps(b.as_ptr().add(i));
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_div_ps(va, vb));
-        i += 4;
+pub(crate) unsafe fn div(a: &[f32], b: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        while i + 4 <= len {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_div_ps(va, vb));
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j] / b[j];
+        }
     }
-    for j in i..len {
-        result[j] = a[j] / b[j];
-    }
-}}
+}

--- a/src/backends/sse2/ops/elementwise.rs
+++ b/src/backends/sse2/ops/elementwise.rs
@@ -7,209 +7,232 @@ use std::arch::x86_64::*;
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn norm_l1(a: &[f32]) -> f32 { unsafe {
-    if a.is_empty() {
-        return 0.0;
+pub(crate) unsafe fn norm_l1(a: &[f32]) -> f32 {
+    unsafe {
+        if a.is_empty() {
+            return 0.0;
+        }
+        let len = a.len();
+        let mut i = 0;
+        let mut acc = _mm_setzero_ps();
+        let sign_mask = _mm_set1_ps(f32::from_bits(0x7FFF_FFFF));
+        while i + 4 <= len {
+            acc = _mm_add_ps(acc, _mm_and_ps(_mm_loadu_ps(a.as_ptr().add(i)), sign_mask));
+            i += 4;
+        }
+        let mut result = {
+            let temp = _mm_add_ps(acc, _mm_movehl_ps(acc, acc));
+            let temp = _mm_add_ss(temp, _mm_shuffle_ps(temp, temp, 1));
+            _mm_cvtss_f32(temp)
+        };
+        for &val in &a[i..] {
+            result += val.abs();
+        }
+        result
     }
-    let len = a.len();
-    let mut i = 0;
-    let mut acc = _mm_setzero_ps();
-    let sign_mask = _mm_set1_ps(f32::from_bits(0x7FFF_FFFF));
-    while i + 4 <= len {
-        acc = _mm_add_ps(acc, _mm_and_ps(_mm_loadu_ps(a.as_ptr().add(i)), sign_mask));
-        i += 4;
-    }
-    let mut result = {
-        let temp = _mm_add_ps(acc, _mm_movehl_ps(acc, acc));
-        let temp = _mm_add_ss(temp, _mm_shuffle_ps(temp, temp, 1));
-        _mm_cvtss_f32(temp)
-    };
-    for &val in &a[i..] {
-        result += val.abs();
-    }
-    result
-}}
+}
 
 /// SSE2 L-infinity norm.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn norm_linf(a: &[f32]) -> f32 { unsafe {
-    if a.is_empty() {
-        return 0.0;
-    }
-    let len = a.len();
-    let mut i = 0;
-    let mut max_vec = _mm_setzero_ps();
-    let sign_mask = _mm_set1_ps(f32::from_bits(0x7FFF_FFFF));
-    while i + 4 <= len {
-        let va = _mm_loadu_ps(a.as_ptr().add(i));
-        max_vec = _mm_max_ps(max_vec, _mm_and_ps(va, sign_mask));
-        i += 4;
-    }
-    let mut result = {
-        let temp = _mm_max_ps(max_vec, _mm_movehl_ps(max_vec, max_vec));
-        let temp = _mm_max_ss(temp, _mm_shuffle_ps(temp, temp, 1));
-        _mm_cvtss_f32(temp)
-    };
-    for &val in &a[i..] {
-        let abs_val = val.abs();
-        if abs_val > result {
-            result = abs_val;
+pub(crate) unsafe fn norm_linf(a: &[f32]) -> f32 {
+    unsafe {
+        if a.is_empty() {
+            return 0.0;
         }
+        let len = a.len();
+        let mut i = 0;
+        let mut max_vec = _mm_setzero_ps();
+        let sign_mask = _mm_set1_ps(f32::from_bits(0x7FFF_FFFF));
+        while i + 4 <= len {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            max_vec = _mm_max_ps(max_vec, _mm_and_ps(va, sign_mask));
+            i += 4;
+        }
+        let mut result = {
+            let temp = _mm_max_ps(max_vec, _mm_movehl_ps(max_vec, max_vec));
+            let temp = _mm_max_ss(temp, _mm_shuffle_ps(temp, temp, 1));
+            _mm_cvtss_f32(temp)
+        };
+        for &val in &a[i..] {
+            let abs_val = val.abs();
+            if abs_val > result {
+                result = abs_val;
+            }
+        }
+        result
     }
-    result
-}}
+}
 
 /// SSE2 scalar multiply.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn scale(a: &[f32], scalar: f32, result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let scalar_vec = _mm_set1_ps(scalar);
-    while i + 4 <= len {
-        _mm_storeu_ps(
-            result.as_mut_ptr().add(i),
-            _mm_mul_ps(_mm_loadu_ps(a.as_ptr().add(i)), scalar_vec),
-        );
-        i += 4;
+pub(crate) unsafe fn scale(a: &[f32], scalar: f32, result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let scalar_vec = _mm_set1_ps(scalar);
+        while i + 4 <= len {
+            _mm_storeu_ps(
+                result.as_mut_ptr().add(i),
+                _mm_mul_ps(_mm_loadu_ps(a.as_ptr().add(i)), scalar_vec),
+            );
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j] * scalar;
+        }
     }
-    for j in i..len {
-        result[j] = a[j] * scalar;
-    }
-}}
+}
 
 /// SSE2 absolute value.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn abs(a: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let sign_mask = _mm_set1_ps(f32::from_bits(0x7FFF_FFFF));
-    while i + 4 <= len {
-        _mm_storeu_ps(
-            result.as_mut_ptr().add(i),
-            _mm_and_ps(_mm_loadu_ps(a.as_ptr().add(i)), sign_mask),
-        );
-        i += 4;
+pub(crate) unsafe fn abs(a: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let sign_mask = _mm_set1_ps(f32::from_bits(0x7FFF_FFFF));
+        while i + 4 <= len {
+            _mm_storeu_ps(
+                result.as_mut_ptr().add(i),
+                _mm_and_ps(_mm_loadu_ps(a.as_ptr().add(i)), sign_mask),
+            );
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j].abs();
+        }
     }
-    for j in i..len {
-        result[j] = a[j].abs();
-    }
-}}
+}
 
 /// SSE2 clamp.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn clamp(a: &[f32], min_val: f32, max_val: f32, result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let min_vec = _mm_set1_ps(min_val);
-    let max_vec = _mm_set1_ps(max_val);
-    while i + 4 <= len {
-        let va = _mm_loadu_ps(a.as_ptr().add(i));
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_min_ps(_mm_max_ps(va, min_vec), max_vec));
-        i += 4;
+pub(crate) unsafe fn clamp(a: &[f32], min_val: f32, max_val: f32, result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let min_vec = _mm_set1_ps(min_val);
+        let max_vec = _mm_set1_ps(max_val);
+        while i + 4 <= len {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_min_ps(_mm_max_ps(va, min_vec), max_vec));
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j].max(min_val).min(max_val);
+        }
     }
-    for j in i..len {
-        result[j] = a[j].max(min_val).min(max_val);
-    }
-}}
+}
 
 /// SSE2 linear interpolation.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn lerp(a: &[f32], b: &[f32], t: f32, result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let t_vec = _mm_set1_ps(t);
-    while i + 4 <= len {
-        let va = _mm_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm_loadu_ps(b.as_ptr().add(i));
-        _mm_storeu_ps(
-            result.as_mut_ptr().add(i),
-            _mm_add_ps(va, _mm_mul_ps(t_vec, _mm_sub_ps(vb, va))),
-        );
-        i += 4;
+pub(crate) unsafe fn lerp(a: &[f32], b: &[f32], t: f32, result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let t_vec = _mm_set1_ps(t);
+        while i + 4 <= len {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            _mm_storeu_ps(
+                result.as_mut_ptr().add(i),
+                _mm_add_ps(va, _mm_mul_ps(t_vec, _mm_sub_ps(vb, va))),
+            );
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j] + t * (b[j] - a[j]);
+        }
     }
-    for j in i..len {
-        result[j] = a[j] + t * (b[j] - a[j]);
-    }
-}}
+}
 
 /// SSE2 fused multiply-add (emulated, no FMA instruction set).
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn fma(a: &[f32], b: &[f32], c: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    while i + 4 <= len {
-        let va = _mm_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm_loadu_ps(b.as_ptr().add(i));
-        let vc = _mm_loadu_ps(c.as_ptr().add(i));
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_add_ps(_mm_mul_ps(va, vb), vc));
-        i += 4;
+pub(crate) unsafe fn fma(a: &[f32], b: &[f32], c: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        while i + 4 <= len {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            let vc = _mm_loadu_ps(c.as_ptr().add(i));
+            _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_add_ps(_mm_mul_ps(va, vb), vc));
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j] * b[j] + c[j];
+        }
     }
-    for j in i..len {
-        result[j] = a[j] * b[j] + c[j];
-    }
-}}
+}
 
 /// SSE2 ReLU activation.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn relu(a: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let zero = _mm_setzero_ps();
-    while i + 4 <= len {
-        _mm_storeu_ps(
-            result.as_mut_ptr().add(i),
-            _mm_max_ps(_mm_loadu_ps(a.as_ptr().add(i)), zero),
-        );
-        i += 4;
+pub(crate) unsafe fn relu(a: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let zero = _mm_setzero_ps();
+        while i + 4 <= len {
+            _mm_storeu_ps(
+                result.as_mut_ptr().add(i),
+                _mm_max_ps(_mm_loadu_ps(a.as_ptr().add(i)), zero),
+            );
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j].max(0.0);
+        }
     }
-    for j in i..len {
-        result[j] = a[j].max(0.0);
-    }
-}}
+}
 
 /// SSE2 square root.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn sqrt(a: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    while i + 4 <= len {
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_sqrt_ps(_mm_loadu_ps(a.as_ptr().add(i))));
-        i += 4;
+pub(crate) unsafe fn sqrt(a: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        while i + 4 <= len {
+            _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_sqrt_ps(_mm_loadu_ps(a.as_ptr().add(i))));
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j].sqrt();
+        }
     }
-    for j in i..len {
-        result[j] = a[j].sqrt();
-    }
-}}
+}
 
 /// SSE2 reciprocal.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn recip(a: &[f32], result: &mut [f32]) { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let one = _mm_set1_ps(1.0);
-    while i + 4 <= len {
-        _mm_storeu_ps(result.as_mut_ptr().add(i), _mm_div_ps(one, _mm_loadu_ps(a.as_ptr().add(i))));
-        i += 4;
+pub(crate) unsafe fn recip(a: &[f32], result: &mut [f32]) {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let one = _mm_set1_ps(1.0);
+        while i + 4 <= len {
+            _mm_storeu_ps(
+                result.as_mut_ptr().add(i),
+                _mm_div_ps(one, _mm_loadu_ps(a.as_ptr().add(i))),
+            );
+            i += 4;
+        }
+        for j in i..len {
+            result[j] = a[j].recip();
+        }
     }
-    for j in i..len {
-        result[j] = a[j].recip();
-    }
-}}
+}

--- a/src/backends/sse2/ops/reductions.rs
+++ b/src/backends/sse2/ops/reductions.rs
@@ -9,87 +9,95 @@ use crate::backends::VectorBackend;
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn dot(a: &[f32], b: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut acc = _mm_setzero_ps();
+pub(crate) unsafe fn dot(a: &[f32], b: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut acc = _mm_setzero_ps();
 
-    while i + 4 <= len {
-        let va = _mm_loadu_ps(a.as_ptr().add(i));
-        let vb = _mm_loadu_ps(b.as_ptr().add(i));
-        acc = _mm_add_ps(acc, _mm_mul_ps(va, vb));
-        i += 4;
+        while i + 4 <= len {
+            let va = _mm_loadu_ps(a.as_ptr().add(i));
+            let vb = _mm_loadu_ps(b.as_ptr().add(i));
+            acc = _mm_add_ps(acc, _mm_mul_ps(va, vb));
+            i += 4;
+        }
+
+        let mut result = horizontal_sum_ps(acc);
+        result += a[i..].iter().zip(&b[i..]).map(|(x, y)| x * y).sum::<f32>();
+        result
     }
-
-    let mut result = horizontal_sum_ps(acc);
-    result += a[i..].iter().zip(&b[i..]).map(|(x, y)| x * y).sum::<f32>();
-    result
-}}
+}
 
 /// SSE2 vector sum.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn sum(a: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut acc = _mm_setzero_ps();
+pub(crate) unsafe fn sum(a: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut acc = _mm_setzero_ps();
 
-    while i + 4 <= len {
-        acc = _mm_add_ps(acc, _mm_loadu_ps(a.as_ptr().add(i)));
-        i += 4;
+        while i + 4 <= len {
+            acc = _mm_add_ps(acc, _mm_loadu_ps(a.as_ptr().add(i)));
+            i += 4;
+        }
+
+        let mut result = horizontal_sum_ps(acc);
+        result += a[i..].iter().sum::<f32>();
+        result
     }
-
-    let mut result = horizontal_sum_ps(acc);
-    result += a[i..].iter().sum::<f32>();
-    result
-}}
+}
 
 /// SSE2 vector max.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn max(a: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut vmax = _mm_set1_ps(a[0]);
+pub(crate) unsafe fn max(a: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut vmax = _mm_set1_ps(a[0]);
 
-    while i + 4 <= len {
-        vmax = _mm_max_ps(vmax, _mm_loadu_ps(a.as_ptr().add(i)));
-        i += 4;
-    }
-
-    let mut result = horizontal_max_ps(vmax);
-    for &val in &a[i..] {
-        if val > result {
-            result = val;
+        while i + 4 <= len {
+            vmax = _mm_max_ps(vmax, _mm_loadu_ps(a.as_ptr().add(i)));
+            i += 4;
         }
+
+        let mut result = horizontal_max_ps(vmax);
+        for &val in &a[i..] {
+            if val > result {
+                result = val;
+            }
+        }
+        result
     }
-    result
-}}
+}
 
 /// SSE2 vector min.
 #[inline]
 #[target_feature(enable = "sse2")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn min(a: &[f32]) -> f32 { unsafe {
-    let len = a.len();
-    let mut i = 0;
-    let mut vmin = _mm_set1_ps(a[0]);
+pub(crate) unsafe fn min(a: &[f32]) -> f32 {
+    unsafe {
+        let len = a.len();
+        let mut i = 0;
+        let mut vmin = _mm_set1_ps(a[0]);
 
-    while i + 4 <= len {
-        vmin = _mm_min_ps(vmin, _mm_loadu_ps(a.as_ptr().add(i)));
-        i += 4;
-    }
-
-    let mut result = horizontal_min_ps(vmin);
-    for &val in &a[i..] {
-        if val < result {
-            result = val;
+        while i + 4 <= len {
+            vmin = _mm_min_ps(vmin, _mm_loadu_ps(a.as_ptr().add(i)));
+            i += 4;
         }
+
+        let mut result = horizontal_min_ps(vmin);
+        for &val in &a[i..] {
+            if val < result {
+                result = val;
+            }
+        }
+        result
     }
-    result
-}}
+}
 
 /// SSE2 argmax.
 #[inline]
@@ -130,9 +138,9 @@ pub(crate) unsafe fn argmin(a: &[f32]) -> usize {
 /// Kahan sum (delegates to scalar).
 #[inline]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub(crate) unsafe fn sum_kahan(a: &[f32]) -> f32 { unsafe {
-    crate::backends::scalar::ScalarBackend::sum_kahan(a)
-}}
+pub(crate) unsafe fn sum_kahan(a: &[f32]) -> f32 {
+    unsafe { crate::backends::scalar::ScalarBackend::sum_kahan(a) }
+}
 
 // Helper: horizontal sum of 4 floats
 #[inline]

--- a/src/blis/compute.rs
+++ b/src/blis/compute.rs
@@ -261,11 +261,7 @@ pub fn gemm_blis(
     }
 
     if let (Some(prof), Some(s)) = (profiler, start) {
-        prof.record(
-            BlisProfileLevel::Macro,
-            s.elapsed().as_nanos() as u64,
-            (2 * m * n * k) as u64,
-        );
+        prof.record(BlisProfileLevel::Macro, s.elapsed().as_nanos() as u64, (2 * m * n * k) as u64);
     }
 
     Ok(())

--- a/src/blis/elementwise.rs
+++ b/src/blis/elementwise.rs
@@ -307,7 +307,8 @@ mod tests {
     #[test]
     fn test_relu_large() {
         let n = 11008; // FFN intermediate size
-        let input: Vec<f32> = (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
+        let input: Vec<f32> =
+            (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
         let mut output = vec![0.0f32; n];
         relu(&input, &mut output).unwrap();
         for (i, (&inp, &out)) in input.iter().zip(output.iter()).enumerate() {
@@ -318,7 +319,8 @@ mod tests {
     #[test]
     fn test_relu_avx2_scalar_parity() {
         for n in [1, 7, 8, 15, 16, 31, 32, 63, 64, 128, 4096] {
-            let input: Vec<f32> = (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 500.0 - 1.0).collect();
+            let input: Vec<f32> =
+                (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 500.0 - 1.0).collect();
             let mut output = vec![0.0f32; n];
             relu(&input, &mut output).unwrap();
             for (i, (&inp, &out)) in input.iter().zip(output.iter()).enumerate() {
@@ -402,7 +404,8 @@ mod tests {
     #[test]
     fn test_mul_scalar_avx2_scalar_parity() {
         for n in [1, 7, 8, 15, 16, 31, 32, 63, 64, 128, 4096] {
-            let input: Vec<f32> = (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 500.0 - 1.0).collect();
+            let input: Vec<f32> =
+                (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 500.0 - 1.0).collect();
             let mut output = vec![0.0f32; n];
             mul_scalar(&input, 2.718, &mut output).unwrap();
             for i in 0..n {

--- a/src/blis/gemv.rs
+++ b/src/blis/gemv.rs
@@ -37,13 +37,7 @@ const GEMV_TILE_THRESHOLD: usize = 4096;
 /// - `c` has length >= `n`
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2", enable = "fma")]
-pub unsafe fn gemv_avx2(
-    k: usize,
-    n: usize,
-    a: &[f32],
-    b: &[f32],
-    c: &mut [f32],
-) {
+pub unsafe fn gemv_avx2(k: usize, n: usize, a: &[f32], b: &[f32], c: &mut [f32]) {
     unsafe {
         use std::arch::x86_64::*;
 
@@ -129,13 +123,7 @@ pub unsafe fn gemv_avx2(
 /// Requires AVX2+FMA CPU features.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2", enable = "fma")]
-unsafe fn gemv_tiled_avx2(
-    k: usize,
-    n: usize,
-    a: &[f32],
-    b: &[f32],
-    c: &mut [f32],
-) {
+unsafe fn gemv_tiled_avx2(k: usize, n: usize, a: &[f32], b: &[f32], c: &mut [f32]) {
     unsafe {
         use std::arch::x86_64::*;
 
@@ -309,11 +297,10 @@ unsafe fn gemv_tiled_avx2(
                 }
                 while j < rem_n {
                     let idx = nt_end + j;
-                    *c.get_unchecked_mut(idx) +=
-                        *a.get_unchecked(ki) * *b.get_unchecked(b0 + j)
-                            + *a.get_unchecked(ki + 1) * *b.get_unchecked(b1 + j)
-                            + *a.get_unchecked(ki + 2) * *b.get_unchecked(b2 + j)
-                            + *a.get_unchecked(ki + 3) * *b.get_unchecked(b3 + j);
+                    *c.get_unchecked_mut(idx) += *a.get_unchecked(ki) * *b.get_unchecked(b0 + j)
+                        + *a.get_unchecked(ki + 1) * *b.get_unchecked(b1 + j)
+                        + *a.get_unchecked(ki + 2) * *b.get_unchecked(b2 + j)
+                        + *a.get_unchecked(ki + 3) * *b.get_unchecked(b3 + j);
                     j += 1;
                 }
                 ki += 4;
@@ -328,7 +315,10 @@ unsafe fn gemv_tiled_avx2(
                 while j < rem8 {
                     let cv = _mm256_loadu_ps(c.get_unchecked(nt_end + j));
                     let bv = _mm256_loadu_ps(b.get_unchecked(bk + j));
-                    _mm256_storeu_ps(c.get_unchecked_mut(nt_end + j), _mm256_fmadd_ps(ak_v, bv, cv));
+                    _mm256_storeu_ps(
+                        c.get_unchecked_mut(nt_end + j),
+                        _mm256_fmadd_ps(ak_v, bv, cv),
+                    );
                     j += 8;
                 }
                 while j < rem_n {
@@ -342,13 +332,7 @@ unsafe fn gemv_tiled_avx2(
 }
 
 /// Scalar fallback GEMV for non-x86 or non-AVX2 platforms
-pub fn gemv_scalar(
-    k: usize,
-    n: usize,
-    a: &[f32],
-    b: &[f32],
-    c: &mut [f32],
-) {
+pub fn gemv_scalar(k: usize, n: usize, a: &[f32], b: &[f32], c: &mut [f32]) {
     // 4-way K-unrolled axpy (auto-vectorizable)
     let k4 = k / 4 * 4;
     for ki in (0..k4).step_by(4) {
@@ -376,13 +360,7 @@ pub fn gemv_scalar(
 }
 
 /// Dispatch GEMV to best available implementation
-pub fn gemv(
-    k: usize,
-    n: usize,
-    a: &[f32],
-    b: &[f32],
-    c: &mut [f32],
-) {
+pub fn gemv(k: usize, n: usize, a: &[f32], b: &[f32], c: &mut [f32]) {
     #[cfg(target_arch = "x86_64")]
     {
         if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
@@ -409,11 +387,7 @@ mod tests {
     fn test_gemv_basic() {
         // 1×3 @ 3×4 → 1×4
         let a = [1.0, 2.0, 3.0];
-        let b = [
-            1.0, 2.0, 3.0, 4.0,
-            5.0, 6.0, 7.0, 8.0,
-            9.0, 10.0, 11.0, 12.0,
-        ];
+        let b = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
         let mut c = [0.0f32; 4];
 
         gemv(3, 4, &a, &b, &mut c);
@@ -429,11 +403,7 @@ mod tests {
     fn test_gemv_identity_row_select() {
         // e_1 @ B should give B[1,:]
         let a = [0.0, 1.0, 0.0];
-        let b = [
-            1.0, 2.0, 3.0,
-            4.0, 5.0, 6.0,
-            7.0, 8.0, 9.0,
-        ];
+        let b = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
         let mut c = [0.0f32; 3];
 
         gemv(3, 3, &a, &b, &mut c);
@@ -481,9 +451,7 @@ mod tests {
         let n = 8192; // > 4096 → tiled path
 
         let a: Vec<f32> = (0..k).map(|i| ((i * 7 + 3) % 100) as f32 / 100.0 - 0.5).collect();
-        let b: Vec<f32> = (0..k * n)
-            .map(|i| ((i * 13 + 7) % 1000) as f32 / 1000.0 - 0.5)
-            .collect();
+        let b: Vec<f32> = (0..k * n).map(|i| ((i * 13 + 7) % 1000) as f32 / 1000.0 - 0.5).collect();
         let mut c_tiled = vec![0.0f32; n];
         let mut c_scalar = vec![0.0f32; n];
 
@@ -492,12 +460,7 @@ mod tests {
 
         for j in 0..n {
             let diff = (c_tiled[j] - c_scalar[j]).abs();
-            assert!(
-                diff < 1e-2,
-                "j={j}: tiled={} scalar={} diff={diff}",
-                c_tiled[j],
-                c_scalar[j]
-            );
+            assert!(diff < 1e-2, "j={j}: tiled={} scalar={} diff={diff}", c_tiled[j], c_scalar[j]);
         }
     }
 
@@ -508,9 +471,7 @@ mod tests {
         let n = 11008;
 
         let a: Vec<f32> = (0..k).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
-        let b: Vec<f32> = (0..k * n)
-            .map(|i| ((i * 13 + 7) % 1000) as f32 / 1000.0 - 0.5)
-            .collect();
+        let b: Vec<f32> = (0..k * n).map(|i| ((i * 13 + 7) % 1000) as f32 / 1000.0 - 0.5).collect();
         let mut c_tiled = vec![0.0f32; n];
         let mut c_scalar = vec![0.0f32; n];
 
@@ -519,12 +480,7 @@ mod tests {
 
         for j in 0..n {
             let diff = (c_tiled[j] - c_scalar[j]).abs();
-            assert!(
-                diff < 1e-1,
-                "j={j}: tiled={} scalar={} diff={diff}",
-                c_tiled[j],
-                c_scalar[j]
-            );
+            assert!(diff < 1e-1, "j={j}: tiled={} scalar={} diff={diff}", c_tiled[j], c_scalar[j]);
         }
     }
 
@@ -535,9 +491,7 @@ mod tests {
         let n = 5000; // > 4096, not multiple of 64 → remainder = 5000 - 4992 = 8
 
         let a: Vec<f32> = (0..k).map(|i| ((i * 7 + 3) % 100) as f32 / 100.0 - 0.5).collect();
-        let b: Vec<f32> = (0..k * n)
-            .map(|i| ((i * 13 + 7) % 1000) as f32 / 1000.0 - 0.5)
-            .collect();
+        let b: Vec<f32> = (0..k * n).map(|i| ((i * 13 + 7) % 1000) as f32 / 1000.0 - 0.5).collect();
         let mut c_tiled = vec![0.0f32; n];
         let mut c_scalar = vec![0.0f32; n];
 
@@ -546,12 +500,7 @@ mod tests {
 
         for j in 0..n {
             let diff = (c_tiled[j] - c_scalar[j]).abs();
-            assert!(
-                diff < 1e-2,
-                "j={j}: tiled={} scalar={} diff={diff}",
-                c_tiled[j],
-                c_scalar[j]
-            );
+            assert!(diff < 1e-2, "j={j}: tiled={} scalar={} diff={diff}", c_tiled[j], c_scalar[j]);
         }
     }
 
@@ -562,9 +511,7 @@ mod tests {
         let n = 8192;
 
         let a: Vec<f32> = (0..k).map(|i| ((i * 7 + 3) % 100) as f32 / 100.0 - 0.5).collect();
-        let b: Vec<f32> = (0..k * n)
-            .map(|i| ((i * 13 + 7) % 1000) as f32 / 1000.0 - 0.5)
-            .collect();
+        let b: Vec<f32> = (0..k * n).map(|i| ((i * 13 + 7) % 1000) as f32 / 1000.0 - 0.5).collect();
         let mut c_tiled = vec![0.0f32; n];
         let mut c_scalar = vec![0.0f32; n];
 
@@ -573,12 +520,7 @@ mod tests {
 
         for j in 0..n {
             let diff = (c_tiled[j] - c_scalar[j]).abs();
-            assert!(
-                diff < 1e-2,
-                "j={j}: tiled={} scalar={} diff={diff}",
-                c_tiled[j],
-                c_scalar[j]
-            );
+            assert!(diff < 1e-2, "j={j}: tiled={} scalar={} diff={diff}", c_tiled[j], c_scalar[j]);
         }
     }
 }

--- a/src/blis/microkernels/avx2.rs
+++ b/src/blis/microkernels/avx2.rs
@@ -24,47 +24,49 @@ pub unsafe fn microkernel_8x6_avx2(
     b: *const f32, // K x NR packed, row-major
     c: *mut f32,   // MR x NR output, column-major
     ldc: usize,    // Leading dimension of C
-) { unsafe {
-    use std::arch::x86_64::*;
+) {
+    unsafe {
+        use std::arch::x86_64::*;
 
-    // Load C into registers (6 columns of 8 elements each)
-    let mut c0 = _mm256_loadu_ps(c);
-    let mut c1 = _mm256_loadu_ps(c.add(ldc));
-    let mut c2 = _mm256_loadu_ps(c.add(2 * ldc));
-    let mut c3 = _mm256_loadu_ps(c.add(3 * ldc));
-    let mut c4 = _mm256_loadu_ps(c.add(4 * ldc));
-    let mut c5 = _mm256_loadu_ps(c.add(5 * ldc));
+        // Load C into registers (6 columns of 8 elements each)
+        let mut c0 = _mm256_loadu_ps(c);
+        let mut c1 = _mm256_loadu_ps(c.add(ldc));
+        let mut c2 = _mm256_loadu_ps(c.add(2 * ldc));
+        let mut c3 = _mm256_loadu_ps(c.add(3 * ldc));
+        let mut c4 = _mm256_loadu_ps(c.add(4 * ldc));
+        let mut c5 = _mm256_loadu_ps(c.add(5 * ldc));
 
-    // Main loop: accumulate A * B into C
-    for p in 0..k {
-        // Load A column (8 elements)
-        let a_col = _mm256_loadu_ps(a.add(p * MR));
+        // Main loop: accumulate A * B into C
+        for p in 0..k {
+            // Load A column (8 elements)
+            let a_col = _mm256_loadu_ps(a.add(p * MR));
 
-        // Load B row elements and broadcast
-        let b0 = _mm256_set1_ps(*b.add(p * NR));
-        let b1 = _mm256_set1_ps(*b.add(p * NR + 1));
-        let b2 = _mm256_set1_ps(*b.add(p * NR + 2));
-        let b3 = _mm256_set1_ps(*b.add(p * NR + 3));
-        let b4 = _mm256_set1_ps(*b.add(p * NR + 4));
-        let b5 = _mm256_set1_ps(*b.add(p * NR + 5));
+            // Load B row elements and broadcast
+            let b0 = _mm256_set1_ps(*b.add(p * NR));
+            let b1 = _mm256_set1_ps(*b.add(p * NR + 1));
+            let b2 = _mm256_set1_ps(*b.add(p * NR + 2));
+            let b3 = _mm256_set1_ps(*b.add(p * NR + 3));
+            let b4 = _mm256_set1_ps(*b.add(p * NR + 4));
+            let b5 = _mm256_set1_ps(*b.add(p * NR + 5));
 
-        // FMA: c[j] += a * b[j]
-        c0 = _mm256_fmadd_ps(a_col, b0, c0);
-        c1 = _mm256_fmadd_ps(a_col, b1, c1);
-        c2 = _mm256_fmadd_ps(a_col, b2, c2);
-        c3 = _mm256_fmadd_ps(a_col, b3, c3);
-        c4 = _mm256_fmadd_ps(a_col, b4, c4);
-        c5 = _mm256_fmadd_ps(a_col, b5, c5);
+            // FMA: c[j] += a * b[j]
+            c0 = _mm256_fmadd_ps(a_col, b0, c0);
+            c1 = _mm256_fmadd_ps(a_col, b1, c1);
+            c2 = _mm256_fmadd_ps(a_col, b2, c2);
+            c3 = _mm256_fmadd_ps(a_col, b3, c3);
+            c4 = _mm256_fmadd_ps(a_col, b4, c4);
+            c5 = _mm256_fmadd_ps(a_col, b5, c5);
+        }
+
+        // Store C back to memory
+        _mm256_storeu_ps(c, c0);
+        _mm256_storeu_ps(c.add(ldc), c1);
+        _mm256_storeu_ps(c.add(2 * ldc), c2);
+        _mm256_storeu_ps(c.add(3 * ldc), c3);
+        _mm256_storeu_ps(c.add(4 * ldc), c4);
+        _mm256_storeu_ps(c.add(5 * ldc), c5);
     }
-
-    // Store C back to memory
-    _mm256_storeu_ps(c, c0);
-    _mm256_storeu_ps(c.add(ldc), c1);
-    _mm256_storeu_ps(c.add(2 * ldc), c2);
-    _mm256_storeu_ps(c.add(3 * ldc), c3);
-    _mm256_storeu_ps(c.add(4 * ldc), c4);
-    _mm256_storeu_ps(c.add(5 * ldc), c5);
-}}
+}
 
 /// Hand-tuned ASM microkernel with software pipelining (8x6 output tile)
 ///
@@ -95,131 +97,133 @@ pub unsafe fn microkernel_8x6_avx2_asm(
     b: *const f32, // K x NR packed, row-major
     c: *mut f32,   // MR x NR output, column-major
     ldc: usize,    // Leading dimension of C
-) { unsafe {
-    use std::arch::x86_64::*;
+) {
+    unsafe {
+        use std::arch::x86_64::*;
 
-    // Handle k < 4 with intrinsics fallback
-    if k < 4 {
-        microkernel_8x6_avx2(k, a, b, c, ldc);
-        return;
+        // Handle k < 4 with intrinsics fallback
+        if k < 4 {
+            microkernel_8x6_avx2(k, a, b, c, ldc);
+            return;
+        }
+
+        // Load C into registers
+        let mut c0 = _mm256_loadu_ps(c);
+        let mut c1 = _mm256_loadu_ps(c.add(ldc));
+        let mut c2 = _mm256_loadu_ps(c.add(2 * ldc));
+        let mut c3 = _mm256_loadu_ps(c.add(3 * ldc));
+        let mut c4 = _mm256_loadu_ps(c.add(4 * ldc));
+        let mut c5 = _mm256_loadu_ps(c.add(5 * ldc));
+
+        let k_unrolled = k / 4;
+        let k_remainder = k % 4;
+
+        // Main loop: 4-way unrolled for software pipelining
+        // Each iteration processes 4 K values
+        for p in 0..k_unrolled {
+            let base_p = p * 4;
+
+            // Iteration 0: Load A[p*4+0], compute with B[p*4+0]
+            let a0 = _mm256_loadu_ps(a.add((base_p) * MR));
+            let b00 = _mm256_broadcast_ss(&*b.add((base_p) * NR));
+            let b01 = _mm256_broadcast_ss(&*b.add((base_p) * NR + 1));
+            let b02 = _mm256_broadcast_ss(&*b.add((base_p) * NR + 2));
+            let b03 = _mm256_broadcast_ss(&*b.add((base_p) * NR + 3));
+            let b04 = _mm256_broadcast_ss(&*b.add((base_p) * NR + 4));
+            let b05 = _mm256_broadcast_ss(&*b.add((base_p) * NR + 5));
+
+            // Iteration 1: Load A[p*4+1], start FMAs for iteration 0
+            let a1 = _mm256_loadu_ps(a.add((base_p + 1) * MR));
+            c0 = _mm256_fmadd_ps(a0, b00, c0);
+            c1 = _mm256_fmadd_ps(a0, b01, c1);
+            c2 = _mm256_fmadd_ps(a0, b02, c2);
+
+            let b10 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR));
+            let b11 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR + 1));
+            let b12 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR + 2));
+
+            c3 = _mm256_fmadd_ps(a0, b03, c3);
+            c4 = _mm256_fmadd_ps(a0, b04, c4);
+            c5 = _mm256_fmadd_ps(a0, b05, c5);
+
+            let b13 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR + 3));
+            let b14 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR + 4));
+            let b15 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR + 5));
+
+            // Iteration 2: Load A[p*4+2], FMAs for iteration 1
+            let a2 = _mm256_loadu_ps(a.add((base_p + 2) * MR));
+            c0 = _mm256_fmadd_ps(a1, b10, c0);
+            c1 = _mm256_fmadd_ps(a1, b11, c1);
+            c2 = _mm256_fmadd_ps(a1, b12, c2);
+
+            let b20 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR));
+            let b21 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR + 1));
+            let b22 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR + 2));
+
+            c3 = _mm256_fmadd_ps(a1, b13, c3);
+            c4 = _mm256_fmadd_ps(a1, b14, c4);
+            c5 = _mm256_fmadd_ps(a1, b15, c5);
+
+            let b23 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR + 3));
+            let b24 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR + 4));
+            let b25 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR + 5));
+
+            // Iteration 3: Load A[p*4+3], FMAs for iteration 2
+            let a3 = _mm256_loadu_ps(a.add((base_p + 3) * MR));
+            c0 = _mm256_fmadd_ps(a2, b20, c0);
+            c1 = _mm256_fmadd_ps(a2, b21, c1);
+            c2 = _mm256_fmadd_ps(a2, b22, c2);
+
+            let b30 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR));
+            let b31 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR + 1));
+            let b32 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR + 2));
+
+            c3 = _mm256_fmadd_ps(a2, b23, c3);
+            c4 = _mm256_fmadd_ps(a2, b24, c4);
+            c5 = _mm256_fmadd_ps(a2, b25, c5);
+
+            let b33 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR + 3));
+            let b34 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR + 4));
+            let b35 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR + 5));
+
+            // FMAs for iteration 3
+            c0 = _mm256_fmadd_ps(a3, b30, c0);
+            c1 = _mm256_fmadd_ps(a3, b31, c1);
+            c2 = _mm256_fmadd_ps(a3, b32, c2);
+            c3 = _mm256_fmadd_ps(a3, b33, c3);
+            c4 = _mm256_fmadd_ps(a3, b34, c4);
+            c5 = _mm256_fmadd_ps(a3, b35, c5);
+        }
+
+        // Handle remainder (k % 4)
+        let base_p = k_unrolled * 4;
+        for p in 0..k_remainder {
+            let pp = base_p + p;
+            let a_col = _mm256_loadu_ps(a.add(pp * MR));
+            let b0 = _mm256_broadcast_ss(&*b.add(pp * NR));
+            let b1 = _mm256_broadcast_ss(&*b.add(pp * NR + 1));
+            let b2 = _mm256_broadcast_ss(&*b.add(pp * NR + 2));
+            let b3 = _mm256_broadcast_ss(&*b.add(pp * NR + 3));
+            let b4 = _mm256_broadcast_ss(&*b.add(pp * NR + 4));
+            let b5 = _mm256_broadcast_ss(&*b.add(pp * NR + 5));
+
+            c0 = _mm256_fmadd_ps(a_col, b0, c0);
+            c1 = _mm256_fmadd_ps(a_col, b1, c1);
+            c2 = _mm256_fmadd_ps(a_col, b2, c2);
+            c3 = _mm256_fmadd_ps(a_col, b3, c3);
+            c4 = _mm256_fmadd_ps(a_col, b4, c4);
+            c5 = _mm256_fmadd_ps(a_col, b5, c5);
+        }
+
+        // Store C back to memory
+        _mm256_storeu_ps(c, c0);
+        _mm256_storeu_ps(c.add(ldc), c1);
+        _mm256_storeu_ps(c.add(2 * ldc), c2);
+        _mm256_storeu_ps(c.add(3 * ldc), c3);
+        _mm256_storeu_ps(c.add(4 * ldc), c4);
+        _mm256_storeu_ps(c.add(5 * ldc), c5);
     }
-
-    // Load C into registers
-    let mut c0 = _mm256_loadu_ps(c);
-    let mut c1 = _mm256_loadu_ps(c.add(ldc));
-    let mut c2 = _mm256_loadu_ps(c.add(2 * ldc));
-    let mut c3 = _mm256_loadu_ps(c.add(3 * ldc));
-    let mut c4 = _mm256_loadu_ps(c.add(4 * ldc));
-    let mut c5 = _mm256_loadu_ps(c.add(5 * ldc));
-
-    let k_unrolled = k / 4;
-    let k_remainder = k % 4;
-
-    // Main loop: 4-way unrolled for software pipelining
-    // Each iteration processes 4 K values
-    for p in 0..k_unrolled {
-        let base_p = p * 4;
-
-        // Iteration 0: Load A[p*4+0], compute with B[p*4+0]
-        let a0 = _mm256_loadu_ps(a.add((base_p) * MR));
-        let b00 = _mm256_broadcast_ss(&*b.add((base_p) * NR));
-        let b01 = _mm256_broadcast_ss(&*b.add((base_p) * NR + 1));
-        let b02 = _mm256_broadcast_ss(&*b.add((base_p) * NR + 2));
-        let b03 = _mm256_broadcast_ss(&*b.add((base_p) * NR + 3));
-        let b04 = _mm256_broadcast_ss(&*b.add((base_p) * NR + 4));
-        let b05 = _mm256_broadcast_ss(&*b.add((base_p) * NR + 5));
-
-        // Iteration 1: Load A[p*4+1], start FMAs for iteration 0
-        let a1 = _mm256_loadu_ps(a.add((base_p + 1) * MR));
-        c0 = _mm256_fmadd_ps(a0, b00, c0);
-        c1 = _mm256_fmadd_ps(a0, b01, c1);
-        c2 = _mm256_fmadd_ps(a0, b02, c2);
-
-        let b10 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR));
-        let b11 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR + 1));
-        let b12 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR + 2));
-
-        c3 = _mm256_fmadd_ps(a0, b03, c3);
-        c4 = _mm256_fmadd_ps(a0, b04, c4);
-        c5 = _mm256_fmadd_ps(a0, b05, c5);
-
-        let b13 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR + 3));
-        let b14 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR + 4));
-        let b15 = _mm256_broadcast_ss(&*b.add((base_p + 1) * NR + 5));
-
-        // Iteration 2: Load A[p*4+2], FMAs for iteration 1
-        let a2 = _mm256_loadu_ps(a.add((base_p + 2) * MR));
-        c0 = _mm256_fmadd_ps(a1, b10, c0);
-        c1 = _mm256_fmadd_ps(a1, b11, c1);
-        c2 = _mm256_fmadd_ps(a1, b12, c2);
-
-        let b20 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR));
-        let b21 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR + 1));
-        let b22 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR + 2));
-
-        c3 = _mm256_fmadd_ps(a1, b13, c3);
-        c4 = _mm256_fmadd_ps(a1, b14, c4);
-        c5 = _mm256_fmadd_ps(a1, b15, c5);
-
-        let b23 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR + 3));
-        let b24 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR + 4));
-        let b25 = _mm256_broadcast_ss(&*b.add((base_p + 2) * NR + 5));
-
-        // Iteration 3: Load A[p*4+3], FMAs for iteration 2
-        let a3 = _mm256_loadu_ps(a.add((base_p + 3) * MR));
-        c0 = _mm256_fmadd_ps(a2, b20, c0);
-        c1 = _mm256_fmadd_ps(a2, b21, c1);
-        c2 = _mm256_fmadd_ps(a2, b22, c2);
-
-        let b30 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR));
-        let b31 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR + 1));
-        let b32 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR + 2));
-
-        c3 = _mm256_fmadd_ps(a2, b23, c3);
-        c4 = _mm256_fmadd_ps(a2, b24, c4);
-        c5 = _mm256_fmadd_ps(a2, b25, c5);
-
-        let b33 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR + 3));
-        let b34 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR + 4));
-        let b35 = _mm256_broadcast_ss(&*b.add((base_p + 3) * NR + 5));
-
-        // FMAs for iteration 3
-        c0 = _mm256_fmadd_ps(a3, b30, c0);
-        c1 = _mm256_fmadd_ps(a3, b31, c1);
-        c2 = _mm256_fmadd_ps(a3, b32, c2);
-        c3 = _mm256_fmadd_ps(a3, b33, c3);
-        c4 = _mm256_fmadd_ps(a3, b34, c4);
-        c5 = _mm256_fmadd_ps(a3, b35, c5);
-    }
-
-    // Handle remainder (k % 4)
-    let base_p = k_unrolled * 4;
-    for p in 0..k_remainder {
-        let pp = base_p + p;
-        let a_col = _mm256_loadu_ps(a.add(pp * MR));
-        let b0 = _mm256_broadcast_ss(&*b.add(pp * NR));
-        let b1 = _mm256_broadcast_ss(&*b.add(pp * NR + 1));
-        let b2 = _mm256_broadcast_ss(&*b.add(pp * NR + 2));
-        let b3 = _mm256_broadcast_ss(&*b.add(pp * NR + 3));
-        let b4 = _mm256_broadcast_ss(&*b.add(pp * NR + 4));
-        let b5 = _mm256_broadcast_ss(&*b.add(pp * NR + 5));
-
-        c0 = _mm256_fmadd_ps(a_col, b0, c0);
-        c1 = _mm256_fmadd_ps(a_col, b1, c1);
-        c2 = _mm256_fmadd_ps(a_col, b2, c2);
-        c3 = _mm256_fmadd_ps(a_col, b3, c3);
-        c4 = _mm256_fmadd_ps(a_col, b4, c4);
-        c5 = _mm256_fmadd_ps(a_col, b5, c5);
-    }
-
-    // Store C back to memory
-    _mm256_storeu_ps(c, c0);
-    _mm256_storeu_ps(c.add(ldc), c1);
-    _mm256_storeu_ps(c.add(2 * ldc), c2);
-    _mm256_storeu_ps(c.add(3 * ldc), c3);
-    _mm256_storeu_ps(c.add(4 * ldc), c4);
-    _mm256_storeu_ps(c.add(5 * ldc), c5);
-}}
+}
 
 /// Phase 2c: True hand-written inline ASM microkernel (8x6 output tile)
 ///
@@ -256,217 +260,219 @@ pub unsafe fn microkernel_8x6_true_asm(
     b: *const f32,
     c: *mut f32,
     ldc: usize,
-) { unsafe {
-    use std::arch::asm;
+) {
+    unsafe {
+        use std::arch::asm;
 
-    // Handle k < 4 with intrinsics fallback for correctness
-    if k < 4 {
-        microkernel_8x6_avx2(k, a, b, c, ldc);
-        return;
-    }
-
-    // ldc in bytes for pointer arithmetic
-    let ldc_bytes = ldc * 4;
-
-    asm!(
-        // ================================================================
-        // Load C into ymm0-ymm5 (6 columns of 8 elements each)
-        // ================================================================
-        "vmovups ymm0, [{c_ptr}]",
-        "vmovups ymm1, [{c_ptr} + {ldc}]",
-        "vmovups ymm2, [{c_ptr} + {ldc}*2]",
-        "lea {tmp}, [{c_ptr} + {ldc}*2]",
-        "vmovups ymm3, [{tmp} + {ldc}]",
-        "vmovups ymm4, [{tmp} + {ldc}*2]",
-        "lea {tmp}, [{tmp} + {ldc}*2]",
-        "vmovups ymm5, [{tmp} + {ldc}]",
-
-        // ================================================================
-        // Pipeline Prologue: Fill A buffer with A[0], A[1], A[2], A[3]
-        // This creates the 4-deep software pipeline
-        // ================================================================
-        "vmovups ymm6, [{a_ptr}]",         // A[0]
-        "vmovups ymm7, [{a_ptr} + 32]",    // A[1]
-        "vmovups ymm8, [{a_ptr} + 64]",    // A[2]
-        "vmovups ymm9, [{a_ptr} + 96]",    // A[3]
-        "add {a_ptr}, 128",                // a_ptr now points to A[4]
-
-        // ================================================================
-        // Main Loop Setup
-        // Process 4 K iterations per loop iteration (4-way unroll)
-        // ================================================================
-        "mov {k_cnt}, {k}",
-        "shr {k_cnt}, 2",                  // k_cnt = k / 4
-        "test {k_cnt}, {k_cnt}",
-        "jz 2f",                           // Skip if k < 4 (handled above, but be safe)
-
-        // ================================================================
-        // Main Loop: 4-way unrolled with software pipelining
-        // Each iteration: use A[k], A[k+1], A[k+2], A[k+3]
-        //                 load A[k+4], A[k+5], A[k+6], A[k+7] for next iter
-        // 12+ instructions between load and use
-        // ================================================================
-        ".p2align 4",                      // Align loop for better I-cache
-        "3:",
-
-        // --- K iteration 0: Use ymm6 (A[0]), load next A[4] into ymm6 ---
-        "vbroadcastss ymm10, dword ptr [{b_ptr}]",
-        "vbroadcastss ymm11, dword ptr [{b_ptr} + 4]",
-        "vbroadcastss ymm12, dword ptr [{b_ptr} + 8]",
-        "vfmadd231ps ymm0, ymm6, ymm10",   // c0 += a0 * b0
-        "vfmadd231ps ymm1, ymm6, ymm11",   // c1 += a0 * b1
-        "vfmadd231ps ymm2, ymm6, ymm12",   // c2 += a0 * b2
-        "vbroadcastss ymm13, dword ptr [{b_ptr} + 12]",
-        "vbroadcastss ymm14, dword ptr [{b_ptr} + 16]",
-        "vbroadcastss ymm15, dword ptr [{b_ptr} + 20]",
-        "vfmadd231ps ymm3, ymm6, ymm13",   // c3 += a0 * b3
-        "vfmadd231ps ymm4, ymm6, ymm14",   // c4 += a0 * b4
-        "vfmadd231ps ymm5, ymm6, ymm15",   // c5 += a0 * b5
-        "vmovups ymm6, [{a_ptr}]",         // Reload A[4] -> ymm6 (reuse register)
-
-        // --- K iteration 1: Use ymm7 (A[1]), load next A[5] into ymm7 ---
-        "vbroadcastss ymm10, dword ptr [{b_ptr} + 24]",
-        "vbroadcastss ymm11, dword ptr [{b_ptr} + 28]",
-        "vbroadcastss ymm12, dword ptr [{b_ptr} + 32]",
-        "vfmadd231ps ymm0, ymm7, ymm10",
-        "vfmadd231ps ymm1, ymm7, ymm11",
-        "vfmadd231ps ymm2, ymm7, ymm12",
-        "vbroadcastss ymm13, dword ptr [{b_ptr} + 36]",
-        "vbroadcastss ymm14, dword ptr [{b_ptr} + 40]",
-        "vbroadcastss ymm15, dword ptr [{b_ptr} + 44]",
-        "vfmadd231ps ymm3, ymm7, ymm13",
-        "vfmadd231ps ymm4, ymm7, ymm14",
-        "vfmadd231ps ymm5, ymm7, ymm15",
-        "vmovups ymm7, [{a_ptr} + 32]",    // Reload A[5] -> ymm7
-
-        // --- K iteration 2: Use ymm8 (A[2]), load next A[6] into ymm8 ---
-        "vbroadcastss ymm10, dword ptr [{b_ptr} + 48]",
-        "vbroadcastss ymm11, dword ptr [{b_ptr} + 52]",
-        "vbroadcastss ymm12, dword ptr [{b_ptr} + 56]",
-        "vfmadd231ps ymm0, ymm8, ymm10",
-        "vfmadd231ps ymm1, ymm8, ymm11",
-        "vfmadd231ps ymm2, ymm8, ymm12",
-        "vbroadcastss ymm13, dword ptr [{b_ptr} + 60]",
-        "vbroadcastss ymm14, dword ptr [{b_ptr} + 64]",
-        "vbroadcastss ymm15, dword ptr [{b_ptr} + 68]",
-        "vfmadd231ps ymm3, ymm8, ymm13",
-        "vfmadd231ps ymm4, ymm8, ymm14",
-        "vfmadd231ps ymm5, ymm8, ymm15",
-        "vmovups ymm8, [{a_ptr} + 64]",    // Reload A[6] -> ymm8
-
-        // --- K iteration 3: Use ymm9 (A[3]), load next A[7] into ymm9 ---
-        "vbroadcastss ymm10, dword ptr [{b_ptr} + 72]",
-        "vbroadcastss ymm11, dword ptr [{b_ptr} + 76]",
-        "vbroadcastss ymm12, dword ptr [{b_ptr} + 80]",
-        "vfmadd231ps ymm0, ymm9, ymm10",
-        "vfmadd231ps ymm1, ymm9, ymm11",
-        "vfmadd231ps ymm2, ymm9, ymm12",
-        "vbroadcastss ymm13, dword ptr [{b_ptr} + 84]",
-        "vbroadcastss ymm14, dword ptr [{b_ptr} + 88]",
-        "vbroadcastss ymm15, dword ptr [{b_ptr} + 92]",
-        "vfmadd231ps ymm3, ymm9, ymm13",
-        "vfmadd231ps ymm4, ymm9, ymm14",
-        "vfmadd231ps ymm5, ymm9, ymm15",
-        "vmovups ymm9, [{a_ptr} + 96]",    // Reload A[7] -> ymm9
-
-        // Advance pointers for next 4 K iterations
-        "add {a_ptr}, 128",                // 4 * MR * sizeof(f32) = 4 * 8 * 4 = 128
-        "add {b_ptr}, 96",                 // 4 * NR * sizeof(f32) = 4 * 6 * 4 = 96
-
-        // Loop control
-        "dec {k_cnt}",
-        "jnz 3b",
-
-        "2:",
-        // ================================================================
-        // Epilogue: Handle k % 4 remainder
-        // At this point ymm6-ymm9 contain stale values, but k_rem iterations
-        // are handled via intrinsics fallback (k < 4 case above)
-        // For k divisible by 4, we're done
-        // ================================================================
-
-        // ================================================================
-        // Store C back from ymm0-ymm5
-        // ================================================================
-        "vmovups [{c_ptr}], ymm0",
-        "vmovups [{c_ptr} + {ldc}], ymm1",
-        "vmovups [{c_ptr} + {ldc}*2], ymm2",
-        "lea {tmp}, [{c_ptr} + {ldc}*2]",
-        "vmovups [{tmp} + {ldc}], ymm3",
-        "vmovups [{tmp} + {ldc}*2], ymm4",
-        "lea {tmp}, [{tmp} + {ldc}*2]",
-        "vmovups [{tmp} + {ldc}], ymm5",
-
-        // Input/output operands
-        a_ptr = inout(reg) a => _,
-        b_ptr = inout(reg) b => _,
-        c_ptr = in(reg) c,
-        k = in(reg) k,
-        ldc = in(reg) ldc_bytes,
-        k_cnt = out(reg) _,
-        tmp = out(reg) _,
-
-        // Clobbers: all ymm registers used
-        out("ymm0") _,
-        out("ymm1") _,
-        out("ymm2") _,
-        out("ymm3") _,
-        out("ymm4") _,
-        out("ymm5") _,
-        out("ymm6") _,
-        out("ymm7") _,
-        out("ymm8") _,
-        out("ymm9") _,
-        out("ymm10") _,
-        out("ymm11") _,
-        out("ymm12") _,
-        out("ymm13") _,
-        out("ymm14") _,
-        out("ymm15") _,
-
-        options(nostack),
-    );
-
-    // Handle k % 4 remainder if any
-    let k_rem = k % 4;
-    if k_rem > 0 {
-        // Pointer arithmetic: we've advanced past k/4*4 iterations
-        let k_done = (k / 4) * 4;
-        let a_rem = a.add(k_done * MR);
-        let b_rem = b.add(k_done * NR);
-
-        // Use intrinsics for remainder (1-3 iterations)
-        use std::arch::x86_64::*;
-
-        let mut c0 = _mm256_loadu_ps(c);
-        let mut c1 = _mm256_loadu_ps(c.add(ldc));
-        let mut c2 = _mm256_loadu_ps(c.add(2 * ldc));
-        let mut c3 = _mm256_loadu_ps(c.add(3 * ldc));
-        let mut c4 = _mm256_loadu_ps(c.add(4 * ldc));
-        let mut c5 = _mm256_loadu_ps(c.add(5 * ldc));
-
-        for p in 0..k_rem {
-            let a_col = _mm256_loadu_ps(a_rem.add(p * MR));
-            let b0 = _mm256_broadcast_ss(&*b_rem.add(p * NR));
-            let b1 = _mm256_broadcast_ss(&*b_rem.add(p * NR + 1));
-            let b2 = _mm256_broadcast_ss(&*b_rem.add(p * NR + 2));
-            let b3 = _mm256_broadcast_ss(&*b_rem.add(p * NR + 3));
-            let b4 = _mm256_broadcast_ss(&*b_rem.add(p * NR + 4));
-            let b5 = _mm256_broadcast_ss(&*b_rem.add(p * NR + 5));
-
-            c0 = _mm256_fmadd_ps(a_col, b0, c0);
-            c1 = _mm256_fmadd_ps(a_col, b1, c1);
-            c2 = _mm256_fmadd_ps(a_col, b2, c2);
-            c3 = _mm256_fmadd_ps(a_col, b3, c3);
-            c4 = _mm256_fmadd_ps(a_col, b4, c4);
-            c5 = _mm256_fmadd_ps(a_col, b5, c5);
+        // Handle k < 4 with intrinsics fallback for correctness
+        if k < 4 {
+            microkernel_8x6_avx2(k, a, b, c, ldc);
+            return;
         }
 
-        _mm256_storeu_ps(c, c0);
-        _mm256_storeu_ps(c.add(ldc), c1);
-        _mm256_storeu_ps(c.add(2 * ldc), c2);
-        _mm256_storeu_ps(c.add(3 * ldc), c3);
-        _mm256_storeu_ps(c.add(4 * ldc), c4);
-        _mm256_storeu_ps(c.add(5 * ldc), c5);
+        // ldc in bytes for pointer arithmetic
+        let ldc_bytes = ldc * 4;
+
+        asm!(
+            // ================================================================
+            // Load C into ymm0-ymm5 (6 columns of 8 elements each)
+            // ================================================================
+            "vmovups ymm0, [{c_ptr}]",
+            "vmovups ymm1, [{c_ptr} + {ldc}]",
+            "vmovups ymm2, [{c_ptr} + {ldc}*2]",
+            "lea {tmp}, [{c_ptr} + {ldc}*2]",
+            "vmovups ymm3, [{tmp} + {ldc}]",
+            "vmovups ymm4, [{tmp} + {ldc}*2]",
+            "lea {tmp}, [{tmp} + {ldc}*2]",
+            "vmovups ymm5, [{tmp} + {ldc}]",
+
+            // ================================================================
+            // Pipeline Prologue: Fill A buffer with A[0], A[1], A[2], A[3]
+            // This creates the 4-deep software pipeline
+            // ================================================================
+            "vmovups ymm6, [{a_ptr}]",         // A[0]
+            "vmovups ymm7, [{a_ptr} + 32]",    // A[1]
+            "vmovups ymm8, [{a_ptr} + 64]",    // A[2]
+            "vmovups ymm9, [{a_ptr} + 96]",    // A[3]
+            "add {a_ptr}, 128",                // a_ptr now points to A[4]
+
+            // ================================================================
+            // Main Loop Setup
+            // Process 4 K iterations per loop iteration (4-way unroll)
+            // ================================================================
+            "mov {k_cnt}, {k}",
+            "shr {k_cnt}, 2",                  // k_cnt = k / 4
+            "test {k_cnt}, {k_cnt}",
+            "jz 2f",                           // Skip if k < 4 (handled above, but be safe)
+
+            // ================================================================
+            // Main Loop: 4-way unrolled with software pipelining
+            // Each iteration: use A[k], A[k+1], A[k+2], A[k+3]
+            //                 load A[k+4], A[k+5], A[k+6], A[k+7] for next iter
+            // 12+ instructions between load and use
+            // ================================================================
+            ".p2align 4",                      // Align loop for better I-cache
+            "3:",
+
+            // --- K iteration 0: Use ymm6 (A[0]), load next A[4] into ymm6 ---
+            "vbroadcastss ymm10, dword ptr [{b_ptr}]",
+            "vbroadcastss ymm11, dword ptr [{b_ptr} + 4]",
+            "vbroadcastss ymm12, dword ptr [{b_ptr} + 8]",
+            "vfmadd231ps ymm0, ymm6, ymm10",   // c0 += a0 * b0
+            "vfmadd231ps ymm1, ymm6, ymm11",   // c1 += a0 * b1
+            "vfmadd231ps ymm2, ymm6, ymm12",   // c2 += a0 * b2
+            "vbroadcastss ymm13, dword ptr [{b_ptr} + 12]",
+            "vbroadcastss ymm14, dword ptr [{b_ptr} + 16]",
+            "vbroadcastss ymm15, dword ptr [{b_ptr} + 20]",
+            "vfmadd231ps ymm3, ymm6, ymm13",   // c3 += a0 * b3
+            "vfmadd231ps ymm4, ymm6, ymm14",   // c4 += a0 * b4
+            "vfmadd231ps ymm5, ymm6, ymm15",   // c5 += a0 * b5
+            "vmovups ymm6, [{a_ptr}]",         // Reload A[4] -> ymm6 (reuse register)
+
+            // --- K iteration 1: Use ymm7 (A[1]), load next A[5] into ymm7 ---
+            "vbroadcastss ymm10, dword ptr [{b_ptr} + 24]",
+            "vbroadcastss ymm11, dword ptr [{b_ptr} + 28]",
+            "vbroadcastss ymm12, dword ptr [{b_ptr} + 32]",
+            "vfmadd231ps ymm0, ymm7, ymm10",
+            "vfmadd231ps ymm1, ymm7, ymm11",
+            "vfmadd231ps ymm2, ymm7, ymm12",
+            "vbroadcastss ymm13, dword ptr [{b_ptr} + 36]",
+            "vbroadcastss ymm14, dword ptr [{b_ptr} + 40]",
+            "vbroadcastss ymm15, dword ptr [{b_ptr} + 44]",
+            "vfmadd231ps ymm3, ymm7, ymm13",
+            "vfmadd231ps ymm4, ymm7, ymm14",
+            "vfmadd231ps ymm5, ymm7, ymm15",
+            "vmovups ymm7, [{a_ptr} + 32]",    // Reload A[5] -> ymm7
+
+            // --- K iteration 2: Use ymm8 (A[2]), load next A[6] into ymm8 ---
+            "vbroadcastss ymm10, dword ptr [{b_ptr} + 48]",
+            "vbroadcastss ymm11, dword ptr [{b_ptr} + 52]",
+            "vbroadcastss ymm12, dword ptr [{b_ptr} + 56]",
+            "vfmadd231ps ymm0, ymm8, ymm10",
+            "vfmadd231ps ymm1, ymm8, ymm11",
+            "vfmadd231ps ymm2, ymm8, ymm12",
+            "vbroadcastss ymm13, dword ptr [{b_ptr} + 60]",
+            "vbroadcastss ymm14, dword ptr [{b_ptr} + 64]",
+            "vbroadcastss ymm15, dword ptr [{b_ptr} + 68]",
+            "vfmadd231ps ymm3, ymm8, ymm13",
+            "vfmadd231ps ymm4, ymm8, ymm14",
+            "vfmadd231ps ymm5, ymm8, ymm15",
+            "vmovups ymm8, [{a_ptr} + 64]",    // Reload A[6] -> ymm8
+
+            // --- K iteration 3: Use ymm9 (A[3]), load next A[7] into ymm9 ---
+            "vbroadcastss ymm10, dword ptr [{b_ptr} + 72]",
+            "vbroadcastss ymm11, dword ptr [{b_ptr} + 76]",
+            "vbroadcastss ymm12, dword ptr [{b_ptr} + 80]",
+            "vfmadd231ps ymm0, ymm9, ymm10",
+            "vfmadd231ps ymm1, ymm9, ymm11",
+            "vfmadd231ps ymm2, ymm9, ymm12",
+            "vbroadcastss ymm13, dword ptr [{b_ptr} + 84]",
+            "vbroadcastss ymm14, dword ptr [{b_ptr} + 88]",
+            "vbroadcastss ymm15, dword ptr [{b_ptr} + 92]",
+            "vfmadd231ps ymm3, ymm9, ymm13",
+            "vfmadd231ps ymm4, ymm9, ymm14",
+            "vfmadd231ps ymm5, ymm9, ymm15",
+            "vmovups ymm9, [{a_ptr} + 96]",    // Reload A[7] -> ymm9
+
+            // Advance pointers for next 4 K iterations
+            "add {a_ptr}, 128",                // 4 * MR * sizeof(f32) = 4 * 8 * 4 = 128
+            "add {b_ptr}, 96",                 // 4 * NR * sizeof(f32) = 4 * 6 * 4 = 96
+
+            // Loop control
+            "dec {k_cnt}",
+            "jnz 3b",
+
+            "2:",
+            // ================================================================
+            // Epilogue: Handle k % 4 remainder
+            // At this point ymm6-ymm9 contain stale values, but k_rem iterations
+            // are handled via intrinsics fallback (k < 4 case above)
+            // For k divisible by 4, we're done
+            // ================================================================
+
+            // ================================================================
+            // Store C back from ymm0-ymm5
+            // ================================================================
+            "vmovups [{c_ptr}], ymm0",
+            "vmovups [{c_ptr} + {ldc}], ymm1",
+            "vmovups [{c_ptr} + {ldc}*2], ymm2",
+            "lea {tmp}, [{c_ptr} + {ldc}*2]",
+            "vmovups [{tmp} + {ldc}], ymm3",
+            "vmovups [{tmp} + {ldc}*2], ymm4",
+            "lea {tmp}, [{tmp} + {ldc}*2]",
+            "vmovups [{tmp} + {ldc}], ymm5",
+
+            // Input/output operands
+            a_ptr = inout(reg) a => _,
+            b_ptr = inout(reg) b => _,
+            c_ptr = in(reg) c,
+            k = in(reg) k,
+            ldc = in(reg) ldc_bytes,
+            k_cnt = out(reg) _,
+            tmp = out(reg) _,
+
+            // Clobbers: all ymm registers used
+            out("ymm0") _,
+            out("ymm1") _,
+            out("ymm2") _,
+            out("ymm3") _,
+            out("ymm4") _,
+            out("ymm5") _,
+            out("ymm6") _,
+            out("ymm7") _,
+            out("ymm8") _,
+            out("ymm9") _,
+            out("ymm10") _,
+            out("ymm11") _,
+            out("ymm12") _,
+            out("ymm13") _,
+            out("ymm14") _,
+            out("ymm15") _,
+
+            options(nostack),
+        );
+
+        // Handle k % 4 remainder if any
+        let k_rem = k % 4;
+        if k_rem > 0 {
+            // Pointer arithmetic: we've advanced past k/4*4 iterations
+            let k_done = (k / 4) * 4;
+            let a_rem = a.add(k_done * MR);
+            let b_rem = b.add(k_done * NR);
+
+            // Use intrinsics for remainder (1-3 iterations)
+            use std::arch::x86_64::*;
+
+            let mut c0 = _mm256_loadu_ps(c);
+            let mut c1 = _mm256_loadu_ps(c.add(ldc));
+            let mut c2 = _mm256_loadu_ps(c.add(2 * ldc));
+            let mut c3 = _mm256_loadu_ps(c.add(3 * ldc));
+            let mut c4 = _mm256_loadu_ps(c.add(4 * ldc));
+            let mut c5 = _mm256_loadu_ps(c.add(5 * ldc));
+
+            for p in 0..k_rem {
+                let a_col = _mm256_loadu_ps(a_rem.add(p * MR));
+                let b0 = _mm256_broadcast_ss(&*b_rem.add(p * NR));
+                let b1 = _mm256_broadcast_ss(&*b_rem.add(p * NR + 1));
+                let b2 = _mm256_broadcast_ss(&*b_rem.add(p * NR + 2));
+                let b3 = _mm256_broadcast_ss(&*b_rem.add(p * NR + 3));
+                let b4 = _mm256_broadcast_ss(&*b_rem.add(p * NR + 4));
+                let b5 = _mm256_broadcast_ss(&*b_rem.add(p * NR + 5));
+
+                c0 = _mm256_fmadd_ps(a_col, b0, c0);
+                c1 = _mm256_fmadd_ps(a_col, b1, c1);
+                c2 = _mm256_fmadd_ps(a_col, b2, c2);
+                c3 = _mm256_fmadd_ps(a_col, b3, c3);
+                c4 = _mm256_fmadd_ps(a_col, b4, c4);
+                c5 = _mm256_fmadd_ps(a_col, b5, c5);
+            }
+
+            _mm256_storeu_ps(c, c0);
+            _mm256_storeu_ps(c.add(ldc), c1);
+            _mm256_storeu_ps(c.add(2 * ldc), c2);
+            _mm256_storeu_ps(c.add(3 * ldc), c3);
+            _mm256_storeu_ps(c.add(4 * ldc), c4);
+            _mm256_storeu_ps(c.add(5 * ldc), c5);
+        }
     }
-}}
+}

--- a/src/blis/norms.rs
+++ b/src/blis/norms.rs
@@ -390,12 +390,7 @@ pub fn rms_norm_alloc(input: &[f32], gamma: &[f32], eps: f32) -> Vec<f32> {
 ///
 /// Panics if input, gamma, and beta have different lengths.
 #[must_use]
-pub fn layer_norm_alloc(
-    input: &[f32],
-    gamma: &[f32],
-    beta: &[f32],
-    eps: f32,
-) -> Vec<f32> {
+pub fn layer_norm_alloc(input: &[f32], gamma: &[f32], beta: &[f32], eps: f32) -> Vec<f32> {
     let n = input.len();
     let mut output = vec![0.0f32; n];
     layer_norm(input, gamma, beta, eps, &mut output).expect("layer_norm_alloc: length mismatch");
@@ -416,7 +411,8 @@ mod tests {
     #[test]
     fn test_rmsnorm_finiteness() {
         for n in [4, 8, 16, 32, 64, 128, 4096] {
-            let input: Vec<f32> = (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
+            let input: Vec<f32> =
+                (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
             let gamma = vec![1.0f32; n];
             let mut output = vec![0.0f32; n];
             rms_norm(&input, &gamma, 1e-5, &mut output).unwrap();
@@ -453,7 +449,8 @@ mod tests {
     #[test]
     fn test_rmsnorm_avx2_scalar_parity() {
         for n in [4, 7, 8, 16, 31, 64, 128, 4096] {
-            let input: Vec<f32> = (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
+            let input: Vec<f32> =
+                (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
             let gamma: Vec<f32> = (0..n).map(|i| 0.5 + (i % 5) as f32 * 0.2).collect();
             let mut scalar_out = vec![0.0f32; n];
             let mut dispatch_out = vec![0.0f32; n];
@@ -497,10 +494,7 @@ mod tests {
 
         let sum_sq: f32 = output.iter().map(|x| x * x).sum();
         let rms_out = (sum_sq / output.len() as f32).sqrt();
-        assert!(
-            (rms_out - 1.0).abs() < 1e-3,
-            "RMS of output = {rms_out}, expected ~1.0"
-        );
+        assert!((rms_out - 1.0).abs() < 1e-3, "RMS of output = {rms_out}, expected ~1.0");
     }
 
     #[test]
@@ -525,7 +519,8 @@ mod tests {
     #[test]
     fn test_layernorm_finiteness() {
         for n in [4, 8, 16, 32, 64, 128, 4096] {
-            let input: Vec<f32> = (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
+            let input: Vec<f32> =
+                (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
             let gamma = vec![1.0f32; n];
             let beta = vec![0.0f32; n];
             let mut output = vec![0.0f32; n];
@@ -540,17 +535,15 @@ mod tests {
     #[test]
     fn test_layernorm_zero_mean() {
         for n in [16, 64, 128, 4096] {
-            let input: Vec<f32> = (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
+            let input: Vec<f32> =
+                (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
             let gamma = vec![1.0f32; n];
             let beta = vec![0.0f32; n];
             let mut output = vec![0.0f32; n];
             layer_norm(&input, &gamma, &beta, 1e-5, &mut output).unwrap();
 
             let mean: f32 = output.iter().sum::<f32>() / n as f32;
-            assert!(
-                mean.abs() < 1e-4,
-                "LayerNorm output mean = {mean}, expected ~0 for n={n}"
-            );
+            assert!(mean.abs() < 1e-4, "LayerNorm output mean = {mean}, expected ~0 for n={n}");
         }
     }
 
@@ -558,7 +551,8 @@ mod tests {
     #[test]
     fn test_layernorm_unit_variance() {
         for n in [16, 64, 128, 4096] {
-            let input: Vec<f32> = (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
+            let input: Vec<f32> =
+                (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
             let gamma = vec![1.0f32; n];
             let beta = vec![0.0f32; n];
             let mut output = vec![0.0f32; n];
@@ -601,7 +595,8 @@ mod tests {
     #[test]
     fn test_layernorm_avx2_scalar_parity() {
         for n in [4, 7, 8, 16, 31, 64, 128, 4096] {
-            let input: Vec<f32> = (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
+            let input: Vec<f32> =
+                (0..n).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
             let gamma: Vec<f32> = (0..n).map(|i| 0.5 + (i % 5) as f32 * 0.2).collect();
             let beta: Vec<f32> = (0..n).map(|i| (i % 3) as f32 * 0.1 - 0.1).collect();
             let mut scalar_out = vec![0.0f32; n];
@@ -632,10 +627,7 @@ mod tests {
         let mut output = vec![0.0f32; 32];
         layer_norm(&input, &gamma, &beta, 1e-5, &mut output).unwrap();
         for (i, (&o, &b)) in output.iter().zip(beta.iter()).enumerate() {
-            assert!(
-                (o - b).abs() < 1e-3,
-                "Constant input: output[{i}]={o}, expected ~beta={b}"
-            );
+            assert!((o - b).abs() < 1e-3, "Constant input: output[{i}]={o}, expected ~beta={b}");
         }
     }
 

--- a/src/blis/softmax.rs
+++ b/src/blis/softmax.rs
@@ -208,9 +208,7 @@ mod tests {
     use super::*;
 
     fn deterministic_f32(len: usize) -> Vec<f32> {
-        (0..len)
-            .map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5)
-            .collect()
+        (0..len).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect()
     }
 
     /// FALSIFY-SM-001: sum(softmax(x)) ≈ 1.0
@@ -220,10 +218,7 @@ mod tests {
             let data = deterministic_f32(n);
             let result = softmax_1d_alloc(&data);
             let sum: f32 = result.iter().sum();
-            assert!(
-                (sum - 1.0).abs() < 1e-5,
-                "sum = {sum} for n={n}, expected 1.0"
-            );
+            assert!((sum - 1.0).abs() < 1e-5, "sum = {sum} for n={n}, expected 1.0");
         }
     }
 
@@ -262,10 +257,7 @@ mod tests {
         let result_b = softmax_1d_alloc(&shifted);
 
         for (i, (&a, &b)) in result_a.iter().zip(result_b.iter()).enumerate() {
-            assert!(
-                (a - b).abs() < 1e-6,
-                "Shift invariance broken at [{i}]: {a} vs {b}"
-            );
+            assert!((a - b).abs() < 1e-6, "Shift invariance broken at [{i}]: {a} vs {b}");
         }
     }
 
@@ -277,10 +269,7 @@ mod tests {
             let result = softmax_1d_alloc(&data);
             let expected = 1.0 / n as f32;
             for (i, &v) in result.iter().enumerate() {
-                assert!(
-                    (v - expected).abs() < 1e-6,
-                    "Uniform at [{i}]: {v} vs {expected}"
-                );
+                assert!((v - expected).abs() < 1e-6, "Uniform at [{i}]: {v} vs {expected}");
             }
         }
     }
@@ -294,10 +283,7 @@ mod tests {
             let scalar_result = softmax_scalar(&data);
 
             for (i, (&a, &s)) in avx2_result.iter().zip(scalar_result.iter()).enumerate() {
-                assert!(
-                    (a - s).abs() < 1e-7,
-                    "AVX2/scalar mismatch at [{i}] n={n}: {a} vs {s}"
-                );
+                assert!((a - s).abs() < 1e-7, "AVX2/scalar mismatch at [{i}] n={n}: {a} vs {s}");
             }
         }
     }
@@ -309,10 +295,7 @@ mod tests {
             let data = deterministic_f32(n);
             let result = softmax_1d_alloc(&data);
             let sum: f32 = result.iter().sum();
-            assert!(
-                (sum - 1.0).abs() < 1e-5,
-                "sum = {sum} for n={n}, expected 1.0"
-            );
+            assert!((sum - 1.0).abs() < 1e-5, "sum = {sum} for n={n}, expected 1.0");
             assert_eq!(result.len(), n);
         }
     }

--- a/src/blis/transpose.rs
+++ b/src/blis/transpose.rs
@@ -171,11 +171,16 @@ pub fn transpose(rows: usize, cols: usize, a: &[f32], b: &mut [f32]) -> Result<(
 /// Requires AVX2 support.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
-unsafe fn transpose_avx2_impl(rows: usize, cols: usize, a: &[f32], b: &mut [f32]) -> Result<(), TruenoError> {
+unsafe fn transpose_avx2_impl(
+    rows: usize,
+    cols: usize,
+    a: &[f32],
+    b: &mut [f32],
+) -> Result<(), TruenoError> {
     use std::arch::x86_64::*;
 
     const TILE: usize = 64; // L1-resident outer tile
-    const BLOCK: usize = 8;  // AVX2 micro-kernel
+    const BLOCK: usize = 8; // AVX2 micro-kernel
 
     let rb_end = rows / BLOCK * BLOCK;
     let cb_end = cols / BLOCK * BLOCK;
@@ -351,9 +356,8 @@ mod tests {
     fn test_attention_shape() {
         let rows = 2048;
         let cols = 128;
-        let a: Vec<f32> = (0..rows * cols)
-            .map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5)
-            .collect();
+        let a: Vec<f32> =
+            (0..rows * cols).map(|i| ((i * 17 + 31) % 1000) as f32 / 1000.0 - 0.5).collect();
         let mut b_test = vec![0.0f32; rows * cols];
         let mut b_ref = vec![0.0f32; rows * cols];
 

--- a/src/brick/attention.rs
+++ b/src/brick/attention.rs
@@ -110,34 +110,36 @@ impl AttentionOp {
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx2", enable = "fma")]
     // SAFETY: caller verifies AVX2 support, input slices meet alignment/length requirements
-    unsafe fn avx2_dot(a: &[f32], b: &[f32]) -> f32 { unsafe {
-        use std::arch::x86_64::*;
+    unsafe fn avx2_dot(a: &[f32], b: &[f32]) -> f32 {
+        unsafe {
+            use std::arch::x86_64::*;
 
-        let mut sum = _mm256_setzero_ps();
-        let chunks = a.len() / 8;
+            let mut sum = _mm256_setzero_ps();
+            let chunks = a.len() / 8;
 
-        for i in 0..chunks {
-            let base = i * 8;
-            let va = _mm256_loadu_ps(a.as_ptr().add(base));
-            let vb = _mm256_loadu_ps(b.as_ptr().add(base));
-            sum = _mm256_fmadd_ps(va, vb, sum);
+            for i in 0..chunks {
+                let base = i * 8;
+                let va = _mm256_loadu_ps(a.as_ptr().add(base));
+                let vb = _mm256_loadu_ps(b.as_ptr().add(base));
+                sum = _mm256_fmadd_ps(va, vb, sum);
+            }
+
+            // Horizontal sum
+            let high = _mm256_extractf128_ps(sum, 1);
+            let low = _mm256_castps256_ps128(sum);
+            let sum128 = _mm_add_ps(high, low);
+            let sum64 = _mm_add_ps(sum128, _mm_movehl_ps(sum128, sum128));
+            let sum32 = _mm_add_ss(sum64, _mm_shuffle_ps(sum64, sum64, 1));
+            let mut result = _mm_cvtss_f32(sum32);
+
+            // Handle remainder
+            for i in (chunks * 8)..a.len() {
+                result += a[i] * b[i];
+            }
+
+            result
         }
-
-        // Horizontal sum
-        let high = _mm256_extractf128_ps(sum, 1);
-        let low = _mm256_castps256_ps128(sum);
-        let sum128 = _mm_add_ps(high, low);
-        let sum64 = _mm_add_ps(sum128, _mm_movehl_ps(sum128, sum128));
-        let sum32 = _mm_add_ss(sum64, _mm_shuffle_ps(sum64, sum64, 1));
-        let mut result = _mm_cvtss_f32(sum32);
-
-        // Handle remainder
-        for i in (chunks * 8)..a.len() {
-            result += a[i] * b[i];
-        }
-
-        result
-    }}
+    }
 
     /// Row-wise softmax with SIMD max/sum.
     #[inline]

--- a/src/brick/exec_graph/node/mod.rs
+++ b/src/brick/exec_graph/node/mod.rs
@@ -295,8 +295,15 @@ impl BrickCategory {
     pub const COUNT: usize = 7;
 
     /// All BrickCategory variants in order, for safe index-based iteration.
-    pub const ALL: [BrickCategory; Self::COUNT] =
-        [Self::Norm, Self::Attention, Self::Ffn, Self::Other, Self::Sparse, Self::Fft, Self::Solver];
+    pub const ALL: [BrickCategory; Self::COUNT] = [
+        Self::Norm,
+        Self::Attention,
+        Self::Ffn,
+        Self::Other,
+        Self::Sparse,
+        Self::Fft,
+        Self::Solver,
+    ];
 
     /// Get the string name of this category.
     #[inline]

--- a/src/brick/memory.rs
+++ b/src/brick/memory.rs
@@ -195,52 +195,54 @@ pub unsafe fn madvise_region(
     addr: *mut u8,
     len: usize,
     advice: MemoryAdvice,
-) -> std::io::Result<()> { unsafe {
-    // madvise syscall number is 28 on x86_64
-    #[cfg(target_arch = "x86_64")]
-    const SYS_MADVISE: i64 = 28;
-    #[cfg(target_arch = "aarch64")]
-    const SYS_MADVISE: i64 = 233;
+) -> std::io::Result<()> {
+    unsafe {
+        // madvise syscall number is 28 on x86_64
+        #[cfg(target_arch = "x86_64")]
+        const SYS_MADVISE: i64 = 28;
+        #[cfg(target_arch = "aarch64")]
+        const SYS_MADVISE: i64 = 233;
 
-    let advice_flag: i32 = match advice {
-        MemoryAdvice::Sequential => MADV_SEQUENTIAL,
-        MemoryAdvice::Random => MADV_RANDOM,
-        MemoryAdvice::WillNeed => MADV_WILLNEED,
-        MemoryAdvice::DontNeed => MADV_DONTNEED,
-    };
+        let advice_flag: i32 = match advice {
+            MemoryAdvice::Sequential => MADV_SEQUENTIAL,
+            MemoryAdvice::Random => MADV_RANDOM,
+            MemoryAdvice::WillNeed => MADV_WILLNEED,
+            MemoryAdvice::DontNeed => MADV_DONTNEED,
+        };
 
-    let ret: i64;
-    #[cfg(target_arch = "x86_64")]
-    {
-        core::arch::asm!(
-            "syscall",
-            inout("rax") SYS_MADVISE => ret,
-            in("rdi") addr as usize,
-            in("rsi") len,
-            in("rdx") advice_flag as i64,
-            out("rcx") _,
-            out("r11") _,
-            options(nostack)
-        );
+        let ret: i64;
+        #[cfg(target_arch = "x86_64")]
+        {
+            core::arch::asm!(
+                "syscall",
+                inout("rax") SYS_MADVISE => ret,
+                in("rdi") addr as usize,
+                in("rsi") len,
+                in("rdx") advice_flag as i64,
+                out("rcx") _,
+                out("r11") _,
+                options(nostack)
+            );
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            core::arch::asm!(
+                "svc 0",
+                inout("x8") SYS_MADVISE => _,
+                inout("x0") addr as usize => ret,
+                in("x1") len,
+                in("x2") advice_flag as i64,
+                options(nostack)
+            );
+        }
+
+        if ret < 0 {
+            return Err(std::io::Error::from_raw_os_error(-ret as i32));
+        }
+
+        Ok(())
     }
-    #[cfg(target_arch = "aarch64")]
-    {
-        core::arch::asm!(
-            "svc 0",
-            inout("x8") SYS_MADVISE => _,
-            inout("x0") addr as usize => ret,
-            in("x1") len,
-            in("x2") advice_flag as i64,
-            options(nostack)
-        );
-    }
-
-    if ret < 0 {
-        return Err(std::io::Error::from_raw_os_error(-ret as i32));
-    }
-
-    Ok(())
-}}
+}
 
 /// Stub for non-Linux platforms.
 #[cfg(not(target_os = "linux"))]
@@ -263,13 +265,15 @@ pub unsafe fn madvise_region(
 /// The pointer must be valid and the length must not exceed the mapped region.
 #[cfg(target_os = "linux")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub unsafe fn prefetch_for_inference(addr: *mut u8, len: usize) -> std::io::Result<()> { unsafe {
-    // First: tell kernel we'll need this data
-    madvise_region(addr, len, MemoryAdvice::WillNeed)?;
-    // Second: hint random access pattern (disables readahead waste)
-    madvise_region(addr, len, MemoryAdvice::Random)?;
-    Ok(())
-}}
+pub unsafe fn prefetch_for_inference(addr: *mut u8, len: usize) -> std::io::Result<()> {
+    unsafe {
+        // First: tell kernel we'll need this data
+        madvise_region(addr, len, MemoryAdvice::WillNeed)?;
+        // Second: hint random access pattern (disables readahead waste)
+        madvise_region(addr, len, MemoryAdvice::Random)?;
+        Ok(())
+    }
+}
 
 /// Stub for non-Linux platforms.
 #[cfg(not(target_os = "linux"))]
@@ -302,15 +306,17 @@ pub enum PrefetchLocality {
 #[inline]
 #[cfg(target_arch = "x86_64")]
 // SAFETY: caller ensures preconditions are met for this unsafe function
-pub unsafe fn prefetch_ptr<T>(ptr: *const T, locality: PrefetchLocality) { unsafe {
-    use core::arch::x86_64::*;
-    match locality {
-        PrefetchLocality::None => _mm_prefetch(ptr as *const i8, _MM_HINT_NTA),
-        PrefetchLocality::Low => _mm_prefetch(ptr as *const i8, _MM_HINT_T2),
-        PrefetchLocality::Moderate => _mm_prefetch(ptr as *const i8, _MM_HINT_T1),
-        PrefetchLocality::High => _mm_prefetch(ptr as *const i8, _MM_HINT_T0),
+pub unsafe fn prefetch_ptr<T>(ptr: *const T, locality: PrefetchLocality) {
+    unsafe {
+        use core::arch::x86_64::*;
+        match locality {
+            PrefetchLocality::None => _mm_prefetch(ptr as *const i8, _MM_HINT_NTA),
+            PrefetchLocality::Low => _mm_prefetch(ptr as *const i8, _MM_HINT_T2),
+            PrefetchLocality::Moderate => _mm_prefetch(ptr as *const i8, _MM_HINT_T1),
+            PrefetchLocality::High => _mm_prefetch(ptr as *const i8, _MM_HINT_T0),
+        }
     }
-}}
+}
 
 /// Prefetch data into cache (ARM64).
 #[inline]

--- a/src/brick/ops/mod.rs
+++ b/src/brick/ops/mod.rs
@@ -289,145 +289,153 @@ impl SoftmaxOp {
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller verifies AVX2 support, input slices meet alignment/length requirements
-    unsafe fn avx2_max(input: &[f32]) -> f32 { unsafe {
-        use std::arch::x86_64::*;
-        let len = input.len();
-        let mut i = 0;
-        let mut vmax = _mm256_set1_ps(f32::NEG_INFINITY);
+    unsafe fn avx2_max(input: &[f32]) -> f32 {
+        unsafe {
+            use std::arch::x86_64::*;
+            let len = input.len();
+            let mut i = 0;
+            let mut vmax = _mm256_set1_ps(f32::NEG_INFINITY);
 
-        while i + 8 <= len {
-            let v = _mm256_loadu_ps(input.as_ptr().add(i));
-            vmax = _mm256_max_ps(vmax, v);
-            i += 8;
+            while i + 8 <= len {
+                let v = _mm256_loadu_ps(input.as_ptr().add(i));
+                vmax = _mm256_max_ps(vmax, v);
+                i += 8;
+            }
+
+            // Horizontal max
+            let high = _mm256_extractf128_ps(vmax, 1);
+            let low = _mm256_castps256_ps128(vmax);
+            let max128 = _mm_max_ps(high, low);
+            let max64 = _mm_max_ps(max128, _mm_movehl_ps(max128, max128));
+            let max32 = _mm_max_ss(max64, _mm_shuffle_ps(max64, max64, 1));
+            let mut result = _mm_cvtss_f32(max32);
+
+            // Handle remainder
+            for &val in &input[i..] {
+                result = result.max(val);
+            }
+            result
         }
-
-        // Horizontal max
-        let high = _mm256_extractf128_ps(vmax, 1);
-        let low = _mm256_castps256_ps128(vmax);
-        let max128 = _mm_max_ps(high, low);
-        let max64 = _mm_max_ps(max128, _mm_movehl_ps(max128, max128));
-        let max32 = _mm_max_ss(max64, _mm_shuffle_ps(max64, max64, 1));
-        let mut result = _mm_cvtss_f32(max32);
-
-        // Handle remainder
-        for &val in &input[i..] {
-            result = result.max(val);
-        }
-        result
-    }}
+    }
 
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx2", enable = "fma")]
     // SAFETY: caller verifies AVX2 support, input slices meet alignment/length requirements
-    unsafe fn avx2_exp(input: &[f32], output: &mut [f32]) { unsafe {
-        use std::arch::x86_64::*;
+    unsafe fn avx2_exp(input: &[f32], output: &mut [f32]) {
+        unsafe {
+            use std::arch::x86_64::*;
 
-        let len = input.len();
-        let mut i = 0;
+            let len = input.len();
+            let mut i = 0;
 
-        // Constants for range reduction (matches llama.cpp ggml_v_expf)
-        let log2e = _mm256_set1_ps(std::f32::consts::LOG2_E);
-        let ln2 = _mm256_set1_ps(std::f32::consts::LN_2);
-        let half = _mm256_set1_ps(0.5);
-        let one = _mm256_set1_ps(1.0);
+            // Constants for range reduction (matches llama.cpp ggml_v_expf)
+            let log2e = _mm256_set1_ps(std::f32::consts::LOG2_E);
+            let ln2 = _mm256_set1_ps(std::f32::consts::LN_2);
+            let half = _mm256_set1_ps(0.5);
+            let one = _mm256_set1_ps(1.0);
 
-        // Remez minimax polynomial coefficients for e^r on [-ln(2)/2, ln(2)/2]
-        let c1 = _mm256_set1_ps(1.0);
-        let c2 = _mm256_set1_ps(0.5);
-        let c3 = _mm256_set1_ps(0.166_666_67);
-        let c4 = _mm256_set1_ps(0.041_666_668);
-        let c5 = _mm256_set1_ps(0.008_333_334);
-        let c6 = _mm256_set1_ps(0.001_388_889);
+            // Remez minimax polynomial coefficients for e^r on [-ln(2)/2, ln(2)/2]
+            let c1 = _mm256_set1_ps(1.0);
+            let c2 = _mm256_set1_ps(0.5);
+            let c3 = _mm256_set1_ps(0.166_666_67);
+            let c4 = _mm256_set1_ps(0.041_666_668);
+            let c5 = _mm256_set1_ps(0.008_333_334);
+            let c6 = _mm256_set1_ps(0.001_388_889);
 
-        let exp_hi = _mm256_set1_ps(88.376_26);
-        let exp_lo = _mm256_set1_ps(-87.336_55);
+            let exp_hi = _mm256_set1_ps(88.376_26);
+            let exp_lo = _mm256_set1_ps(-87.336_55);
 
-        while i + 8 <= len {
-            let x = _mm256_loadu_ps(input.as_ptr().add(i));
-            let x = _mm256_max_ps(_mm256_min_ps(x, exp_hi), exp_lo);
+            while i + 8 <= len {
+                let x = _mm256_loadu_ps(input.as_ptr().add(i));
+                let x = _mm256_max_ps(_mm256_min_ps(x, exp_hi), exp_lo);
 
-            // Range reduction: x' = x * log2(e), k = round(x'), r = (x' - k) * ln2
-            let fx = _mm256_fmadd_ps(x, log2e, half);
-            let fx = _mm256_floor_ps(fx);
-            let r = _mm256_fnmadd_ps(fx, ln2, x);
+                // Range reduction: x' = x * log2(e), k = round(x'), r = (x' - k) * ln2
+                let fx = _mm256_fmadd_ps(x, log2e, half);
+                let fx = _mm256_floor_ps(fx);
+                let r = _mm256_fnmadd_ps(fx, ln2, x);
 
-            // Polynomial: e^r ≈ 1 + r + r²/2 + r³/6 + r⁴/24 + r⁵/120 + r⁶/720
-            // Using Horner's method for efficient evaluation
-            let p = _mm256_fmadd_ps(c6, r, c5);
-            let p = _mm256_fmadd_ps(p, r, c4);
-            let p = _mm256_fmadd_ps(p, r, c3);
-            let p = _mm256_fmadd_ps(p, r, c2);
-            let p = _mm256_fmadd_ps(p, r, c1);
-            let p = _mm256_fmadd_ps(p, r, one);
+                // Polynomial: e^r ≈ 1 + r + r²/2 + r³/6 + r⁴/24 + r⁵/120 + r⁶/720
+                // Using Horner's method for efficient evaluation
+                let p = _mm256_fmadd_ps(c6, r, c5);
+                let p = _mm256_fmadd_ps(p, r, c4);
+                let p = _mm256_fmadd_ps(p, r, c3);
+                let p = _mm256_fmadd_ps(p, r, c2);
+                let p = _mm256_fmadd_ps(p, r, c1);
+                let p = _mm256_fmadd_ps(p, r, one);
 
-            // Scale by 2^k using integer exponent manipulation
-            let k = _mm256_cvtps_epi32(fx);
-            let k = _mm256_add_epi32(k, _mm256_set1_epi32(127));
-            let k = _mm256_slli_epi32(k, 23);
-            let pow2k = _mm256_castsi256_ps(k);
-            let result = _mm256_mul_ps(p, pow2k);
+                // Scale by 2^k using integer exponent manipulation
+                let k = _mm256_cvtps_epi32(fx);
+                let k = _mm256_add_epi32(k, _mm256_set1_epi32(127));
+                let k = _mm256_slli_epi32(k, 23);
+                let pow2k = _mm256_castsi256_ps(k);
+                let result = _mm256_mul_ps(p, pow2k);
 
-            _mm256_storeu_ps(output.as_mut_ptr().add(i), result);
-            i += 8;
+                _mm256_storeu_ps(output.as_mut_ptr().add(i), result);
+                i += 8;
+            }
+
+            // Scalar remainder
+            for j in i..len {
+                output[j] = input[j].exp();
+            }
         }
-
-        // Scalar remainder
-        for j in i..len {
-            output[j] = input[j].exp();
-        }
-    }}
+    }
 
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller verifies AVX2 support, input slices meet alignment/length requirements
-    unsafe fn avx2_sum(input: &[f32]) -> f32 { unsafe {
-        use std::arch::x86_64::*;
-        let len = input.len();
-        let mut i = 0;
-        let mut acc = _mm256_setzero_ps();
+    unsafe fn avx2_sum(input: &[f32]) -> f32 {
+        unsafe {
+            use std::arch::x86_64::*;
+            let len = input.len();
+            let mut i = 0;
+            let mut acc = _mm256_setzero_ps();
 
-        while i + 8 <= len {
-            let v = _mm256_loadu_ps(input.as_ptr().add(i));
-            acc = _mm256_add_ps(acc, v);
-            i += 8;
+            while i + 8 <= len {
+                let v = _mm256_loadu_ps(input.as_ptr().add(i));
+                acc = _mm256_add_ps(acc, v);
+                i += 8;
+            }
+
+            // Horizontal sum
+            let high = _mm256_extractf128_ps(acc, 1);
+            let low = _mm256_castps256_ps128(acc);
+            let sum128 = _mm_add_ps(high, low);
+            let sum64 = _mm_add_ps(sum128, _mm_movehl_ps(sum128, sum128));
+            let sum32 = _mm_add_ss(sum64, _mm_shuffle_ps(sum64, sum64, 1));
+            let mut result = _mm_cvtss_f32(sum32);
+
+            // Handle remainder
+            for &val in &input[i..] {
+                result += val;
+            }
+            result
         }
-
-        // Horizontal sum
-        let high = _mm256_extractf128_ps(acc, 1);
-        let low = _mm256_castps256_ps128(acc);
-        let sum128 = _mm_add_ps(high, low);
-        let sum64 = _mm_add_ps(sum128, _mm_movehl_ps(sum128, sum128));
-        let sum32 = _mm_add_ss(sum64, _mm_shuffle_ps(sum64, sum64, 1));
-        let mut result = _mm_cvtss_f32(sum32);
-
-        // Handle remainder
-        for &val in &input[i..] {
-            result += val;
-        }
-        result
-    }}
+    }
 
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx2")]
     // SAFETY: caller verifies AVX2 support, input slices meet alignment/length requirements
-    unsafe fn avx2_scale(input: &[f32], scalar: f32, output: &mut [f32]) { unsafe {
-        use std::arch::x86_64::*;
-        let len = input.len();
-        let mut i = 0;
-        let vscalar = _mm256_set1_ps(scalar);
+    unsafe fn avx2_scale(input: &[f32], scalar: f32, output: &mut [f32]) {
+        unsafe {
+            use std::arch::x86_64::*;
+            let len = input.len();
+            let mut i = 0;
+            let vscalar = _mm256_set1_ps(scalar);
 
-        while i + 8 <= len {
-            let v = _mm256_loadu_ps(input.as_ptr().add(i));
-            let result = _mm256_mul_ps(v, vscalar);
-            _mm256_storeu_ps(output.as_mut_ptr().add(i), result);
-            i += 8;
-        }
+            while i + 8 <= len {
+                let v = _mm256_loadu_ps(input.as_ptr().add(i));
+                let result = _mm256_mul_ps(v, vscalar);
+                _mm256_storeu_ps(output.as_mut_ptr().add(i), result);
+                i += 8;
+            }
 
-        // Scalar remainder
-        for j in i..len {
-            output[j] = input[j] * scalar;
+            // Scalar remainder
+            for j in i..len {
+                output[j] = input[j] * scalar;
+            }
         }
-    }}
+    }
 }
 
 #[cfg(test)]

--- a/src/brick/quant_ops/mod.rs
+++ b/src/brick/quant_ops/mod.rs
@@ -181,29 +181,31 @@ impl DotQ5KOp {
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx2", enable = "fma")]
     // SAFETY: caller verifies AVX2 support, input slices meet alignment/length requirements
-    unsafe fn avx2_dot_block(block: &BlockQ5K, x: &[f32]) -> f32 { unsafe {
-        use std::arch::x86_64::*;
+    unsafe fn avx2_dot_block(block: &BlockQ5K, x: &[f32]) -> f32 {
+        unsafe {
+            use std::arch::x86_64::*;
 
-        let mut acc = _mm256_setzero_ps();
-        let mut dequant = [0.0f32; BlockQ5K::BLOCK_SIZE];
-        block.dequantize(&mut dequant);
+            let mut acc = _mm256_setzero_ps();
+            let mut dequant = [0.0f32; BlockQ5K::BLOCK_SIZE];
+            block.dequantize(&mut dequant);
 
-        let mut i = 0;
-        while i + 8 <= BlockQ5K::BLOCK_SIZE {
-            let vd = _mm256_loadu_ps(dequant.as_ptr().add(i));
-            let vx = _mm256_loadu_ps(x.as_ptr().add(i));
-            acc = _mm256_fmadd_ps(vd, vx, acc);
-            i += 8;
+            let mut i = 0;
+            while i + 8 <= BlockQ5K::BLOCK_SIZE {
+                let vd = _mm256_loadu_ps(dequant.as_ptr().add(i));
+                let vx = _mm256_loadu_ps(x.as_ptr().add(i));
+                acc = _mm256_fmadd_ps(vd, vx, acc);
+                i += 8;
+            }
+
+            // Horizontal sum
+            let high = _mm256_extractf128_ps(acc, 1);
+            let low = _mm256_castps256_ps128(acc);
+            let sum128 = _mm_add_ps(high, low);
+            let sum64 = _mm_add_ps(sum128, _mm_movehl_ps(sum128, sum128));
+            let sum32 = _mm_add_ss(sum64, _mm_shuffle_ps(sum64, sum64, 1));
+            _mm_cvtss_f32(sum32)
         }
-
-        // Horizontal sum
-        let high = _mm256_extractf128_ps(acc, 1);
-        let low = _mm256_castps256_ps128(acc);
-        let sum128 = _mm_add_ps(high, low);
-        let sum64 = _mm_add_ps(sum128, _mm_movehl_ps(sum128, sum128));
-        let sum32 = _mm_add_ss(sum64, _mm_shuffle_ps(sum64, sum64, 1));
-        _mm_cvtss_f32(sum32)
-    }}
+    }
 }
 
 impl ComputeOp for DotQ5KOp {
@@ -278,29 +280,31 @@ impl DotQ6KOp {
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx2", enable = "fma")]
     // SAFETY: caller verifies AVX2 support, input slices meet alignment/length requirements
-    unsafe fn avx2_dot_block(block: &BlockQ6K, x: &[f32]) -> f32 { unsafe {
-        use std::arch::x86_64::*;
+    unsafe fn avx2_dot_block(block: &BlockQ6K, x: &[f32]) -> f32 {
+        unsafe {
+            use std::arch::x86_64::*;
 
-        let mut acc = _mm256_setzero_ps();
-        let mut dequant = [0.0f32; BlockQ6K::BLOCK_SIZE];
-        block.dequantize(&mut dequant);
+            let mut acc = _mm256_setzero_ps();
+            let mut dequant = [0.0f32; BlockQ6K::BLOCK_SIZE];
+            block.dequantize(&mut dequant);
 
-        let mut i = 0;
-        while i + 8 <= BlockQ6K::BLOCK_SIZE {
-            let vd = _mm256_loadu_ps(dequant.as_ptr().add(i));
-            let vx = _mm256_loadu_ps(x.as_ptr().add(i));
-            acc = _mm256_fmadd_ps(vd, vx, acc);
-            i += 8;
+            let mut i = 0;
+            while i + 8 <= BlockQ6K::BLOCK_SIZE {
+                let vd = _mm256_loadu_ps(dequant.as_ptr().add(i));
+                let vx = _mm256_loadu_ps(x.as_ptr().add(i));
+                acc = _mm256_fmadd_ps(vd, vx, acc);
+                i += 8;
+            }
+
+            // Horizontal sum
+            let high = _mm256_extractf128_ps(acc, 1);
+            let low = _mm256_castps256_ps128(acc);
+            let sum128 = _mm_add_ps(high, low);
+            let sum64 = _mm_add_ps(sum128, _mm_movehl_ps(sum128, sum128));
+            let sum32 = _mm_add_ss(sum64, _mm_shuffle_ps(sum64, sum64, 1));
+            _mm_cvtss_f32(sum32)
         }
-
-        // Horizontal sum
-        let high = _mm256_extractf128_ps(acc, 1);
-        let low = _mm256_castps256_ps128(acc);
-        let sum128 = _mm_add_ps(high, low);
-        let sum64 = _mm_add_ps(sum128, _mm_movehl_ps(sum128, sum128));
-        let sum32 = _mm_add_ss(sum64, _mm_shuffle_ps(sum64, sum64, 1));
-        _mm_cvtss_f32(sum32)
-    }}
+    }
 }
 
 impl ComputeOp for DotQ6KOp {

--- a/src/matrix/ops/linear/mod.rs
+++ b/src/matrix/ops/linear/mod.rs
@@ -88,12 +88,9 @@ impl Matrix<f32> {
         // BLIS transpose handles AVX2 dispatch, remainder edges, and shape-adaptive
         // loop ordering internally. Dimensions are correct by construction so
         // the only possible error (size mismatch) cannot occur.
-        if let Err(e) = crate::blis::transpose::transpose(
-            self.rows,
-            self.cols,
-            &self.data,
-            &mut result.data,
-        ) {
+        if let Err(e) =
+            crate::blis::transpose::transpose(self.rows, self.cols, &self.data, &mut result.data)
+        {
             // Unreachable: result is allocated as cols×rows which matches rows×cols elements.
             // If somehow triggered, fall back to scalar element-wise transpose.
             debug_assert!(false, "BLIS transpose dimension mismatch: {e}");

--- a/trueno-gpu/src/kernels/backward/cross_entropy.rs
+++ b/trueno-gpu/src/kernels/backward/cross_entropy.rs
@@ -81,14 +81,14 @@ impl Kernel for FusedCrossEntropyKernel {
         // Phases 1-2 complete all logit reads before phase 3 writes (barrier-protected).
         PtxKernel::new("fused_cross_entropy")
             .param(PtxType::U64, "logits_grad_ptr") // [seq_len, vocab_size] f32 — logits in, grad out
-            .param(PtxType::U64, "targets_ptr")     // [seq_len] u32
-            .param(PtxType::U64, "loss_ptr")        // [seq_len] f32 (output)
+            .param(PtxType::U64, "targets_ptr") // [seq_len] u32
+            .param(PtxType::U64, "loss_ptr") // [seq_len] f32 (output)
             .param(PtxType::U32, "vocab_size")
-            .param(PtxType::F32, "scale")            // 1.0 / seq_len (or 1/(seq_len * accum_steps))
+            .param(PtxType::F32, "scale") // 1.0 / seq_len (or 1/(seq_len * accum_steps))
             .shared_memory(smem_size as usize)
             .build(|ctx| {
                 let tid = ctx.special_reg(PtxReg::TidX);
-                let pos = ctx.special_reg(PtxReg::CtaIdX);  // block = position
+                let pos = ctx.special_reg(PtxReg::CtaIdX); // block = position
                 let ntid = ctx.special_reg(PtxReg::NtidX);
 
                 let lane_mask = ctx.mov_u32_imm(31);
@@ -398,8 +398,8 @@ impl Kernel for FusedCausalCrossEntropyKernel {
             .param(PtxType::U64, "loss_ptr")
             .param(PtxType::U32, "vocab_size")
             .param(PtxType::F32, "scale")
-            .param(PtxType::U32, "loss_start")  // KAIZEN-064: first loss position
-            .param(PtxType::U32, "loss_end")    // KAIZEN-064: one-past-last loss position
+            .param(PtxType::U32, "loss_start") // KAIZEN-064: first loss position
+            .param(PtxType::U32, "loss_end") // KAIZEN-064: one-past-last loss position
             .shared_memory(smem_size as usize)
             .build(|ctx| {
                 let tid = ctx.special_reg(PtxReg::TidX);

--- a/trueno-gpu/src/kernels/backward/gemm.rs
+++ b/trueno-gpu/src/kernels/backward/gemm.rs
@@ -730,7 +730,7 @@ impl GemmBackwardBKernel {
 
                 // --- Load grad_c tile: grad_c[tile_m + tid_y, block_n + tid_x] ---
                 let gc_m_row = a_m_row; // same M position
-                let gc_n_col = col;     // block_n + tid_x
+                let gc_n_col = col; // block_n + tid_x
 
                 let zero_gc = ctx.mov_f32_imm(0.0);
                 ctx.st_shared_f32(smem_gc_offset, zero_gc);

--- a/trueno-gpu/src/kernels/backward/mod.rs
+++ b/trueno-gpu/src/kernels/backward/mod.rs
@@ -134,7 +134,10 @@ mod tests {
         assert_eq!(SoftmaxBackwardKernel::new(16, 16).name(), "softmax_backward");
         assert_eq!(BatchedSoftmaxBackwardKernel::new(16, 64).name(), "batched_softmax_backward");
         assert_eq!(RmsNormBackwardKernel::new(16, 16, 1e-5).name(), "rms_norm_backward");
-        assert_eq!(BatchedRmsNormBackwardKernel::new(16, 64, 1e-5).name(), "batched_rms_norm_backward");
+        assert_eq!(
+            BatchedRmsNormBackwardKernel::new(16, 64, 1e-5).name(),
+            "batched_rms_norm_backward"
+        );
         assert_eq!(LayerNormBackwardKernel::new(16, 16).name(), "layer_norm_backward");
         assert_eq!(GemmBackwardAKernel::new(32, 32, 32).name(), "gemm_backward_a");
         assert_eq!(GemmBackwardBKernel::new(32, 32, 32).name(), "gemm_backward_b");

--- a/trueno-gpu/src/kernels/mod.rs
+++ b/trueno-gpu/src/kernels/mod.rs
@@ -93,13 +93,14 @@ pub use persistent::PersistentDecoderKernel;
 pub use quantize::{
     dequantize_nf4, pack_nf4_for_gpu, quantize_nf4, unpack_nf4_from_gpu, BatchedQ4KGemvKernel,
     BatchedQ6KGemvKernel, ChunkedTiledQ4KGemvKernel, CoalescedQ4KGemvKernel,
-    CoalescedQ6KGemvKernel, Dp4aQ4KGemvKernel, Dp4aQ6KGemvKernel, Fp16Q4KGemvKernel, FusedGateUpQ4KGemvKernel, MultiWarpQ6KGemvKernel,
-    FusedRmsNormGateUpSwigluQ4KKernel, FusedRmsNormQ4KGemvKernel, MultiWarpVectorizedQ4KGemvKernel,
-    MwvDp4aQ4KGemvKernel, Nf4GemmKernel, Nf4Quantized, PackedDp4aQ4KQ8Kernel, Q4KGemvKernel,
-    Q4KQ8DotKernel, Q4_0GemvKernel, Q4_1GemvKernel, Q5KGemvKernel, Q5KKernel, Q5_0GemvKernel,
-    Q6KGemvKernel, Q6KKernel, Q8QuantizeKernel, Q8_0GemvKernel, QuantizeKernel,
-    TensorCoreQ4KGemmKernel, TiledQ4KGemvKernel, TrueDp4aQ4KGemvKernel,
-    VectorizedQ4KGemvKernel, WideQ4KGemvKernel, NF4_BLOCK_BYTES, NF4_BLOCK_SIZE, NF4_LUT,
+    CoalescedQ6KGemvKernel, Dp4aQ4KGemvKernel, Dp4aQ6KGemvKernel, Fp16Q4KGemvKernel,
+    FusedGateUpQ4KGemvKernel, FusedRmsNormGateUpSwigluQ4KKernel, FusedRmsNormQ4KGemvKernel,
+    MultiWarpQ6KGemvKernel, MultiWarpVectorizedQ4KGemvKernel, MwvDp4aQ4KGemvKernel, Nf4GemmKernel,
+    Nf4Quantized, PackedDp4aQ4KQ8Kernel, Q4KGemvKernel, Q4KQ8DotKernel, Q4_0GemvKernel,
+    Q4_1GemvKernel, Q5KGemvKernel, Q5KKernel, Q5_0GemvKernel, Q6KGemvKernel, Q6KKernel,
+    Q8QuantizeKernel, Q8_0GemvKernel, QuantizeKernel, TensorCoreQ4KGemmKernel, TiledQ4KGemvKernel,
+    TrueDp4aQ4KGemvKernel, VectorizedQ4KGemvKernel, WideQ4KGemvKernel, NF4_BLOCK_BYTES,
+    NF4_BLOCK_SIZE, NF4_LUT,
 };
 pub use softmax::{LongRowSoftmaxKernel, SoftmaxKernel};
 

--- a/trueno-gpu/src/kernels/quantize/mod.rs
+++ b/trueno-gpu/src/kernels/quantize/mod.rs
@@ -49,17 +49,20 @@ pub use fused::{
     FusedGateUpQ4KGemvKernel, FusedRmsNormGateUpSwigluQ4KKernel, FusedRmsNormQ4KGemvKernel,
 };
 pub use legacy::{Q4_0GemvKernel, Q4_1GemvKernel, Q5_0GemvKernel, Q8_0GemvKernel};
+pub use nf4::Nf4GemmKernel;
+pub use nf4_cpu::{
+    dequantize_nf4, pack_nf4_for_gpu, quantize_nf4, unpack_nf4_from_gpu, Nf4Quantized,
+    NF4_BLOCK_BYTES, NF4_BLOCK_SIZE, NF4_LUT,
+};
 pub use q4k::{
     BatchedQ4KGemvKernel, ChunkedTiledQ4KGemvKernel, CoalescedQ4KGemvKernel, Dp4aQ4KGemvKernel,
     MultiWarpVectorizedQ4KGemvKernel, MwvDp4aQ4KGemvKernel, Q4KGemvKernel, TiledQ4KGemvKernel,
     TrueDp4aQ4KGemvKernel, VectorizedQ4KGemvKernel, WideQ4KGemvKernel,
 };
 pub use q5k::{Q5KGemvKernel, Q5KKernel};
-pub use q6k::{BatchedQ6KGemvKernel, CoalescedQ6KGemvKernel, Dp4aQ6KGemvKernel, MultiWarpQ6KGemvKernel, Q6KGemvKernel, Q6KKernel};
-pub use nf4::Nf4GemmKernel;
-pub use nf4_cpu::{
-    dequantize_nf4, pack_nf4_for_gpu, quantize_nf4, unpack_nf4_from_gpu, Nf4Quantized,
-    NF4_BLOCK_BYTES, NF4_BLOCK_SIZE, NF4_LUT,
+pub use q6k::{
+    BatchedQ6KGemvKernel, CoalescedQ6KGemvKernel, Dp4aQ6KGemvKernel, MultiWarpQ6KGemvKernel,
+    Q6KGemvKernel, Q6KKernel,
 };
 pub use q8::Q8QuantizeKernel;
 

--- a/trueno-gpu/src/kernels/quantize/nf4.rs
+++ b/trueno-gpu/src/kernels/quantize/nf4.rs
@@ -91,10 +91,10 @@ impl Kernel for Nf4GemmKernel {
         let smem_size = 16 * 4;
 
         PtxKernel::new("nf4_gemm_fused")
-            .param(PtxType::U64, "a_ptr")        // Activations [M × K], f32
-            .param(PtxType::U64, "b_nf4_ptr")    // Packed nibbles
-            .param(PtxType::U64, "b_scales_ptr")  // Per-block scales, f32
-            .param(PtxType::U64, "c_ptr")         // Output [M × N], f32
+            .param(PtxType::U64, "a_ptr") // Activations [M × K], f32
+            .param(PtxType::U64, "b_nf4_ptr") // Packed nibbles
+            .param(PtxType::U64, "b_scales_ptr") // Per-block scales, f32
+            .param(PtxType::U64, "c_ptr") // Output [M × N], f32
             .param(PtxType::U32, "m")
             .param(PtxType::U32, "n")
             .param(PtxType::U32, "k")

--- a/trueno-gpu/src/kernels/quantize/nf4_cpu.rs
+++ b/trueno-gpu/src/kernels/quantize/nf4_cpu.rs
@@ -123,11 +123,7 @@ pub fn quantize_nf4(values: &[f32], rows: usize, cols: usize) -> Nf4Quantized {
         n % NF4_BLOCK_SIZE == 0,
         "C-NF4-002: value count {n} not divisible by NF4 block size {NF4_BLOCK_SIZE}"
     );
-    assert_eq!(
-        rows * cols,
-        n,
-        "C-NF4-002: shape ({rows}, {cols}) does not match value count {n}"
-    );
+    assert_eq!(rows * cols, n, "C-NF4-002: shape ({rows}, {cols}) does not match value count {n}");
 
     let num_blocks = n / NF4_BLOCK_SIZE;
     let mut scales = Vec::with_capacity(num_blocks);
@@ -138,9 +134,7 @@ pub fn quantize_nf4(values: &[f32], rows: usize, cols: usize) -> Nf4Quantized {
         let block = &values[start..start + NF4_BLOCK_SIZE];
 
         // Compute absmax for this block
-        let absmax = block
-            .iter()
-            .fold(0.0f32, |acc, &v| acc.max(v.abs()));
+        let absmax = block.iter().fold(0.0f32, |acc, &v| acc.max(v.abs()));
 
         scales.push(absmax);
 
@@ -340,10 +334,7 @@ mod tests {
 
         // Monotonically increasing
         for i in 1..16 {
-            assert!(
-                NF4_LUT[i] > NF4_LUT[i - 1],
-                "NF4_LUT not monotonic at index {i}"
-            );
+            assert!(NF4_LUT[i] > NF4_LUT[i - 1], "NF4_LUT not monotonic at index {i}");
         }
     }
 

--- a/trueno-gpu/src/kernels/quantize/q6k/dp4a.rs
+++ b/trueno-gpu/src/kernels/quantize/q6k/dp4a.rs
@@ -231,11 +231,8 @@ impl Kernel for Dp4aQ6KGemvKernel {
                 // === Process 2 halves: n_idx=0 (elements 0-127), n_idx=1 (128-255) ===
                 for n_idx in 0..2u32 {
                     // ql byte offset = 64*n_idx + ql_base_in_half
-                    let ql_full_offset = if n_idx == 0 {
-                        ql_base_in_half
-                    } else {
-                        ctx.add_u32(ql_base_in_half, 64)
-                    };
+                    let ql_full_offset =
+                        if n_idx == 0 { ql_base_in_half } else { ctx.add_u32(ql_base_in_half, 64) };
                     let ql_off_64 = ctx.cvt_u64_u32(ql_full_offset);
                     let ql_addr = ctx.add_u64(sb_addr, ql_off_64);
                     let ql_int32 = ctx.ld_global_u32(ql_addr);
@@ -413,10 +410,7 @@ mod tests {
         for warps in [1, 2, 3, 4, 6, 8] {
             let kernel = Dp4aQ6KGemvKernel::with_warps(1536, 1536, warps);
             let ptx = kernel.emit_ptx();
-            assert!(
-                ptx.contains(".visible .entry"),
-                "Must produce valid PTX for {warps} warps"
-            );
+            assert!(ptx.contains(".visible .entry"), "Must produce valid PTX for {warps} warps");
         }
     }
 

--- a/trueno-gpu/src/kernels/quantize/q6k/multi_warp.rs
+++ b/trueno-gpu/src/kernels/quantize/q6k/multi_warp.rs
@@ -201,14 +201,14 @@ impl Kernel for MultiWarpQ6KGemvKernel {
                 // is = 0 for lanes 0-15, 1 for lanes 16-31
                 // ds_even = ds[8*n + 2*g], ds_odd = ds[8*n + 2*g + 1]
                 let offset_params: [(u32, u32, u32, usize, usize); 8] = [
-                    (0,   0, 0, 0,  1),   // n=0, g=0: scale_idx = 0 or 1
-                    (32,  0, 1, 2,  3),   // n=0, g=1: scale_idx = 2 or 3
-                    (64,  0, 2, 4,  5),   // n=0, g=2: scale_idx = 4 or 5
-                    (96,  0, 3, 6,  7),   // n=0, g=3: scale_idx = 6 or 7
-                    (128, 1, 0, 8,  9),   // n=1, g=0: scale_idx = 8 or 9
-                    (160, 1, 1, 10, 11),  // n=1, g=1: scale_idx = 10 or 11
-                    (192, 1, 2, 12, 13),  // n=1, g=2: scale_idx = 12 or 13
-                    (224, 1, 3, 14, 15),  // n=1, g=3: scale_idx = 14 or 15
+                    (0, 0, 0, 0, 1),     // n=0, g=0: scale_idx = 0 or 1
+                    (32, 0, 1, 2, 3),    // n=0, g=1: scale_idx = 2 or 3
+                    (64, 0, 2, 4, 5),    // n=0, g=2: scale_idx = 4 or 5
+                    (96, 0, 3, 6, 7),    // n=0, g=3: scale_idx = 6 or 7
+                    (128, 1, 0, 8, 9),   // n=1, g=0: scale_idx = 8 or 9
+                    (160, 1, 1, 10, 11), // n=1, g=1: scale_idx = 10 or 11
+                    (192, 1, 2, 12, 13), // n=1, g=2: scale_idx = 12 or 13
+                    (224, 1, 3, 14, 15), // n=1, g=3: scale_idx = 14 or 15
                 ];
 
                 // Precompute lane_is: 0 for lanes 0-15, 1 for lanes 16-31
@@ -413,11 +413,7 @@ mod tests {
     fn test_mwv_q6k_barrier_safety() {
         let kernel = MultiWarpQ6KGemvKernel::new(1536, 1536);
         let result = kernel.analyze_barrier_safety();
-        assert!(
-            result.is_safe,
-            "MWV Q6K must be barrier-safe: {:?}",
-            result.violations
-        );
+        assert!(result.is_safe, "MWV Q6K must be barrier-safe: {:?}", result.violations);
     }
 
     /// Contract: kernel name is deterministic
@@ -435,14 +431,8 @@ mod tests {
         for warps in [1, 2, 3, 4, 6, 8] {
             let kernel = MultiWarpQ6KGemvKernel::with_warps(1536, 1536, warps);
             let ptx = kernel.emit_ptx();
-            assert!(
-                ptx.contains(".visible .entry"),
-                "Must produce valid PTX for {warps} warps"
-            );
-            assert!(
-                ptx.contains("bar.sync"),
-                "Must have barrier even for 1 warp (PARITY-114)"
-            );
+            assert!(ptx.contains(".visible .entry"), "Must produce valid PTX for {warps} warps");
+            assert!(ptx.contains("bar.sync"), "Must have barrier even for 1 warp (PARITY-114)");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Auto-formatted with `cargo fmt` (Rust 1.93.0)
- Prerequisite for unified CI lint gate deployment
- No functional changes — formatting only

## Context
Part of unified CI pipeline rollout ([spec](https://github.com/paiml/infra/blob/main/docs/specifications/unified-ci-pipeline.md)).
The lint gate requires `cargo fmt --check` to pass.

Generated with [Claude Code](https://claude.com/claude-code)