### PR TITLE
chore: bump trueno-gpu to 0.4.35

### DIFF
--- a/trueno-gpu/Cargo.toml
+++ b/trueno-gpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trueno-gpu"
-version = "0.4.34"
+version = "0.4.35"
 edition = "2021"
 authors = ["Pragmatic AI Labs"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Version bump for crates.io publish
- Includes PTX backward branch post-processor for Blackwell sm_121 JIT workaround (GH-480)

## Test plan

- [x] All CI gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)