### PR TITLE
fix: nightly uses checkout-inside-workspace + symlink pattern

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,16 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: paiml/provable-contracts
-          path: ../provable-contracts
+          path: provable-contracts
+
+      - name: Symlink provable-contracts for Cargo path deps
+        if: runner.os != 'Windows'
+        run: ln -sf "$GITHUB_WORKSPACE/provable-contracts" "$GITHUB_WORKSPACE/../provable-contracts"
+
+      - name: Symlink provable-contracts (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: New-Item -ItemType Junction -Path "$env:GITHUB_WORKSPACE\..\provable-contracts" -Target "$env:GITHUB_WORKSPACE\provable-contracts" -Force
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
Hardened `actions/checkout` rejects `path: ../provable-contracts` outside the workspace. Fix uses the proven pattern from aprender/forjar/copia.

## Before
```yaml
path: ../provable-contracts  # ← rejected
```

## After
```yaml
path: provable-contracts  # ← inside workspace
# + symlink to ../provable-contracts at runtime
# + Windows Junction equivalent
```

Fixes #247
Refs paiml/infra#15

🤖 Generated with [Claude Code](https://claude.com/claude-code)